### PR TITLE
Remove profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ and environment variables.
 
 | Option                      | Evironment                | Description                  |
 | --------------------------- | ------------------------- | ---------------------------- |
-| `profile`                   | `BINDPLANE_TF_PROFILE`    | The name of the bindplane profile to use. Profile options are overridden by other configured options. | 
 | `remote_url`                | `BINDPLANE_TF_REMOTE_URL` | The URL for the BindPlane server.  |
 | `username`                  | `BINDPLANE_TF_USERNAME`   | The BindPlane basic auth username. |
 | `password`                  | `BINDPLANE_TF_PASSWORD`   | The BindPlane basic auth password. |
@@ -42,39 +41,6 @@ provider "bindplane" {
 // environment variables are set.
 provider "bindplane" {
   remote_url = "http://192.168.1.10:3001"
-}
-```
-
-#### Profile
-
-A BindPlane profile can be used instead of specifying each option.
-
-
-Asuming you have a profile named `local`, you can specify it in the provider configuration. This
-example shows a profile with `username`, `password`, and `remoteURL` configured.
-```bash
-$ bindplane profile get local
-name: local
-apiVersion: bindplane.observiq.com/v1
-auth:
-  username: admin
-  password: admin
-network:
-  remoteURL: http://localhost:3001
-
-```
-```tf
-provider "bindplane" {
-  profile = "local"
-}
-```
-
-You can override options set by the profile by specifying them in the
-provider configuration. This example shows that the `remote_url` can be overridden.
-```tf
-provider "bindplane" {
-  profile = "local"
-  remote_url = "https://bindplane.corp.net:443"
 }
 ```
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -21,39 +21,22 @@ package client
 import (
 	"context"
 	"fmt"
-	"os"
-	"path"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/observiq/bindplane-op/cli/commands/profile"
 	"github.com/observiq/bindplane-op/client"
 	"github.com/observiq/bindplane-op/config"
 	"github.com/observiq/bindplane-op/model"
 	"go.uber.org/zap"
-	"gopkg.in/yaml.v3"
 )
 
-// New takes an optional profile name, configuration options and
-// returns a BindPlane client. Configuration options will override
-// any parameters that are set in the profile.
-func New(profileName string, options ...Option) (*BindPlane, error) {
+// New takes an configuration options and returns a BindPlane client.
+func New(options ...Option) (*BindPlane, error) {
 	config := &config.Config{}
 	var err error
 
-	// Profile is optional.
-	if profileName != "" {
-		// reading a profile will set default values into the config
-		// which can be overriden by options.
-		config, err = readProfile(profileName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read named profile: %v", err)
-		}
-	}
-
-	// Options can override values set by the profile.
 	for _, option := range options {
 		if option != nil {
 			option(config)
@@ -73,31 +56,6 @@ func New(profileName string, options ...Option) (*BindPlane, error) {
 	}
 
 	return &BindPlane{i}, nil
-}
-
-// readProfile reads a BindPlane profile from the user's bindplane
-// directory. It is assumed that the path is '~/.bindplane'.
-func readProfile(name string) (*config.Config, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("failed to lookup user's home directory: %v", err)
-	}
-
-	dir := path.Clean(fmt.Sprintf("%s/.bindplane/profiles", home))
-
-	profiler := profile.NewProfiler(dir)
-
-	b, err := profiler.ReadProfileBytes(name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read profile %s: %v", name, err)
-	}
-
-	conf := &config.Config{}
-	if err := yaml.Unmarshal(b, conf); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal profile into config: %v", err)
-	}
-
-	return conf, nil
 }
 
 // Option is a function that configures a BindPlane client configuration

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestNew(t *testing.T) {
 	c, err := New(
-		"",
 		WithEndpoint("http://go.dev"),
 		WithUsername("otelu"),
 		WithPassword("otelp"),
@@ -35,7 +34,7 @@ func TestNew(t *testing.T) {
 
 // BindPlane is not configured, API calls should fail
 func TestApply(t *testing.T) {
-	i, err := New("")
+	i, err := New()
 	require.NoError(t, err)
 	require.NotNil(t, i)
 	require.Error(t, i.Apply(&model.AnyResource{}, false))
@@ -43,7 +42,7 @@ func TestApply(t *testing.T) {
 
 // BindPlane is not configured, API calls should fail
 func TestConfiguration(t *testing.T) {
-	i, err := New("")
+	i, err := New()
 	require.NoError(t, err)
 	require.NotNil(t, i)
 
@@ -53,7 +52,7 @@ func TestConfiguration(t *testing.T) {
 
 // BindPlane is not configured, API calls should fail
 func TestDeleteConfiguration(t *testing.T) {
-	i, err := New("")
+	i, err := New()
 	require.NoError(t, err)
 	require.NotNil(t, i)
 

--- a/internal/client/integration_test.go
+++ b/internal/client/integration_test.go
@@ -110,7 +110,6 @@ func TestIntegration_http_raw_config(t *testing.T) {
 	}
 
 	i, err := New(
-		"",
 		WithEndpoint(endpoint.String()),
 		WithUsername(username),
 		WithPassword(password),
@@ -169,7 +168,6 @@ func TestIntegration_http_config(t *testing.T) {
 	}
 
 	i, err := New(
-		"",
 		WithEndpoint(endpoint.String()),
 		WithUsername(username),
 		WithPassword(password),
@@ -328,7 +326,6 @@ func TestIntegration_invalidProtocol(t *testing.T) {
 	}
 
 	i, err := New(
-		"",
 		WithEndpoint(endpoint.String()),
 		WithUsername(username),
 		WithPassword(password),
@@ -365,7 +362,6 @@ func TestIntegration_https(t *testing.T) {
 	}
 
 	i, err := New(
-		"",
 		WithEndpoint(endpoint.String()),
 		WithUsername(username),
 		WithPassword(password),
@@ -406,7 +402,6 @@ func TestIntegration_https(t *testing.T) {
 // 	}
 
 // 	i, err := New(
-//      "",
 // 		WithEndpoint(endpoint.String()),
 // 		WithUsername(username),
 // 		WithPassword(password),
@@ -445,7 +440,6 @@ func TestIntegration_mtls(t *testing.T) {
 	}
 
 	i, err := New(
-		"",
 		WithEndpoint(endpoint.String()),
 		WithUsername(username),
 		WithPassword(password),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	envProfile   = "BINDPLANE_TF_PROFILE"
 	envRemoteURL = "BINDPLANE_TF_REMOTE_URL"
 	envUsername  = "BINDPLANE_TF_USERNAME" // #nosec, credentials are not hardcoded
 	envPassword  = "BINDPLANE_TF_PASSWORD" // #nosec, credentials are not hardcoded
@@ -42,14 +41,6 @@ const (
 func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"profile": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					envProfile,
-				}, nil),
-				Description: "Name of the bindplane client profile in ~/.bindplane. All other configuration options will override values set by the profile.",
-			},
 			"remote_url": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -118,11 +109,6 @@ func Provider() *schema.Provider {
 // providerConfigure configures the BindPlane client, which can be accessed from data / resource
 // functions with with 'bindplane := meta.(client.BindPlane)'
 func providerConfigure(_ context.Context, d *schema.ResourceData, _ *schema.Provider) (any, diag.Diagnostics) {
-	profile := ""
-	if v, ok := d.Get("profile").(string); ok {
-		profile = v
-	}
-
 	clientOpts := []client.Option{}
 
 	if v, ok := d.Get("remote_url").(string); ok && v != "" {
@@ -147,7 +133,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData, _ *schema.Prov
 		}
 	}
 
-	i, err := client.New(profile, clientOpts...)
+	i, err := client.New(clientOpts...)
 	if err != nil {
 		err = fmt.Errorf("failed to initialize bindplane client: %w", err)
 		return nil, diag.FromErr(err)

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -7,10 +7,9 @@ terraform {
 }
 
 provider "bindplane" {
-  profile = "local"
-  # remote_url = "http://localhost:3001"
-  # username = "admin"
-  # password = "admin"
+  remote_url = "http://localhost:3001"
+  username = "admin"
+  password = "admin"
 }
 
 resource "bindplane_raw_configuration" "raw" {


### PR DESCRIPTION
I am working on supporting oss and enterprise clients. Profile support is getting in the way. Profiles may be re-introduced after enterprise client is supported.