### PR TITLE
feat: Detect if resource exists before creating it

### DIFF
--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -136,8 +136,23 @@ func resourceConfiguration() *schema.Resource {
 }
 
 func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
+	bindplane := meta.(*client.BindPlane)
+
 	name := d.Get("name").(string)
 	rollout := d.Get("rollout").(bool)
+
+	// If id is unset, it means Terraform has not previously created
+	// this resource. Check to ensure a resource with this name does
+	// not already exist.
+	if d.Id() == "" {
+		c, err := bindplane.Configuration(name)
+		if err != nil {
+			return err
+		}
+		if c != nil {
+			return fmt.Errorf("configuration with name '%s' already exists with id '%s'", name, c.ID())
+		}
+	}
 
 	labels, err := maputil.StringMapFromTFMap(d.Get("labels").(map[string]any))
 	if err != nil {
@@ -208,7 +223,6 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
 	}
 
 	resource := resource.AnyResourceFromConfigurationV1(config)
-	bindplane := meta.(*client.BindPlane)
 	ctx := context.Background()
 	timeout := d.Timeout(schema.TimeoutCreate) - time.Minute
 	if err := bindplane.ApplyWithRetry(ctx, timeout, &resource, rollout); err != nil {
@@ -229,6 +243,19 @@ func resourceConfigurationRead(d *schema.ResourceData, meta any) error {
 	if config == nil {
 		d.SetId("")
 		return nil
+	}
+
+	// If the state ID is set but differs from the ID returned by,
+	// bindplane, mark the resource to be re-created by unsetting
+	// the ID. This will cause Terraform to attempt to create the resource
+	// instead of updating it. The creation step will fail because
+	// the resource already exists. This behavior is desirable, it will
+	// prevent Terraform from modifying resources created by other means.
+	if id := d.Id(); id != "" {
+		if config.ID() != d.Id() {
+			d.SetId("")
+			return nil
+		}
 	}
 
 	if err := d.Set("name", config.Name()); err != nil {

--- a/provider/resource_generic.go
+++ b/provider/resource_generic.go
@@ -47,6 +47,19 @@ func genericResourceRead(rKind model.Kind, d *schema.ResourceData, meta any) err
 
 	d.SetId(g.ID)
 
+	// If the state ID is set but differs from the ID returned by,
+	// bindplane, mark the resource to be re-created by unsetting
+	// the ID. This will cause Terraform to attempt to create the resource
+	// instead of updating it. The creation step will fail because
+	// the resource already exists. This behavior is desirable, it will
+	// prevent Terraform from modifying resources created by other means.
+	if id := d.Id(); id != "" {
+		if g.ID != d.Id() {
+			d.SetId("")
+			return nil
+		}
+	}
+
 	if err := d.Set("name", g.Name); err != nil {
 		return err
 	}

--- a/provider/resource_processor.go
+++ b/provider/resource_processor.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -66,9 +67,24 @@ func resourceProcessor() *schema.Resource {
 }
 
 func resourceProcessorCreate(d *schema.ResourceData, meta any) error {
+	bindplane := meta.(*client.BindPlane)
+
 	processorType := d.Get("type").(string)
 	name := d.Get("name").(string)
 	rollout := d.Get("rollout").(bool)
+
+	// If id is unset, it means Terraform has not previously created
+	// this resource. Check to ensure a resource with this name does
+	// not already exist.
+	if d.Id() == "" {
+		c, err := bindplane.Configuration(name)
+		if err != nil {
+			return err
+		}
+		if c != nil {
+			return fmt.Errorf("processor with name '%s' already exists with id '%s'", name, c.ID())
+		}
+	}
 
 	parameters := []model.Parameter{}
 	if s := d.Get("parameters_json").(string); s != "" {
@@ -84,7 +100,6 @@ func resourceProcessorCreate(d *schema.ResourceData, meta any) error {
 		return err
 	}
 
-	bindplane := meta.(*client.BindPlane)
 	ctx := context.Background()
 	timeout := d.Timeout(schema.TimeoutCreate) - time.Minute
 	if err := bindplane.ApplyWithRetry(ctx, timeout, &r, rollout); err != nil {

--- a/provider/resource_source.go
+++ b/provider/resource_source.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -67,9 +68,24 @@ func resourceSource() *schema.Resource {
 }
 
 func resourceSourceCreate(d *schema.ResourceData, meta any) error {
+	bindplane := meta.(*client.BindPlane)
+
 	sourceType := d.Get("type").(string)
 	name := d.Get("name").(string)
 	rollout := d.Get("rollout").(bool)
+
+	// If id is unset, it means Terraform has not previously created
+	// this resource. Check to ensure a resource with this name does
+	// not already exist.
+	if d.Id() == "" {
+		c, err := bindplane.Configuration(name)
+		if err != nil {
+			return err
+		}
+		if c != nil {
+			return fmt.Errorf("source with name '%s' already exists with id '%s'", name, c.ID())
+		}
+	}
 
 	parameters := []model.Parameter{}
 	if s := d.Get("parameters_json").(string); s != "" {
@@ -85,7 +101,6 @@ func resourceSourceCreate(d *schema.ResourceData, meta any) error {
 		return err
 	}
 
-	bindplane := meta.(*client.BindPlane)
 	ctx := context.Background()
 	timeout := d.Timeout(schema.TimeoutCreate) - time.Minute
 	if err := bindplane.ApplyWithRetry(ctx, timeout, &r, rollout); err != nil {


### PR DESCRIPTION
In order to prevent Terraform from modifying resources created outside of Terraform, added the following to all resources.

**Create**

When creating a resource (configuration, source, processor, destination) for the first time (when `d.Id() == ""`), check to see if that resource exists on the server side by getting it by name. If the resource exists, that means it was created outside of terraform (because terraform does not have the resource in its state already). Refuse to create the resource.

**Read**

When the terraform state has an ID, and it differs from the ID of the resource read from bindplane, set the state ID to `""`. This will remove the resource from the state and cause terraform to call `create`, which will end up bombing out (appropriately) because the resource already exists outside of bindplane.

**Delete**

We do not have to take action in Delete. Delete is only called if terraform has the resource saved in its state, which can only happen if `read` sets the Id. Read zeros out the ID if it detects that the remote (bindplane) has a resource with a differing ID with the same name.