### PR TITLE
feat(test): Detect bindplane module version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,6 @@ jobs:
           key: tooling-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
 
       - run: make test-end-to-end
-        env:
-          BINDPLANE_LICENSE: ${{ secrets.BINDPLANE_LICENSE }}
 
   build:
     # Skip build for dependabot. It takes long and requires our GPG

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,13 @@ jobs:
     runs-on: "ubuntu-22.04"
     needs:
       - setup-environment
+    strategy:
+      matrix:
+        bindplane_version:
+          - "latest"
+          - "module" # Use the current Go module version
+          - "v1.34.0"
+          - "v1.32.0"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -249,6 +256,8 @@ jobs:
           key: tooling-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
 
       - run: make test-end-to-end
+        env:
+          BINDPLANE_VERSION: ${{ matrix.bindplane_version }}
 
   build:
     # Skip build for dependabot. It takes long and requires our GPG

--- a/Makefile
+++ b/Makefile
@@ -98,18 +98,18 @@ test-cover: vet
 
 .PHONY: test-integration
 test-integration: dev-tls
-	BINDPLANE_VERSION=$(BINDPLANE_VERSION) go test ./... --tags=integration -cover
+	@BINDPLANE_VERSION=$(BINDPLANE_VERSION) go test ./... --tags=integration -cover
 
 .PHONY: test-integration-cover
 test-integration-cover: dev-tls
-	BINDPLANE_VERSION=$(BINDPLANE_VERSION) go test ./... --tags=integration -cover -coverprofile cover.out
+	@BINDPLANE_VERSION=$(BINDPLANE_VERSION) go test ./... --tags=integration -cover -coverprofile cover.out
 	go tool cover -html=cover.out
 
 .PHONY: test-end-to-end
 test-end-to-end: test-integration provider
 	mkdir -p test/integration/providers
 	cp dist/provider_$(GOOS)_$(GOARCH_FULL)/terraform-provider-bindplane* test/integration/providers/terraform-provider-bindplane_v0.0.0
-	BINDPLANE_VERSION=$(BINDPLANE_VERSION) BINDPLANE_LICENSE=${BINDPLANE_LICENSE} bash test/integration/test.sh
+	@BINDPLANE_VERSION=$(BINDPLANE_VERSION) bash test/integration/test.sh
 
 # Test local configures test/local directory
 # with the provider.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ ALL_SRC := $(shell find . -name '*.go' -o -name '*.sh' -type f | sort)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+BINDPLANE_VERSION := $(shell go list -m all | grep github.com/observiq/bindplane-op-enterprise | awk '{print $$2}')
 
 ifeq ($(GOOS), windows)
 EXT?=.exe
@@ -97,18 +98,18 @@ test-cover: vet
 
 .PHONY: test-integration
 test-integration: dev-tls
-	go test ./... --tags=integration -cover
+	BINDPLANE_VERSION=$(BINDPLANE_VERSION) go test ./... --tags=integration -cover
 
 .PHONY: test-integration-cover
 test-integration-cover: dev-tls
-	go test ./... --tags=integration -cover -coverprofile cover.out
+	BINDPLANE_VERSION=$(BINDPLANE_VERSION) go test ./... --tags=integration -cover -coverprofile cover.out
 	go tool cover -html=cover.out
 
 .PHONY: test-end-to-end
 test-end-to-end: test-integration provider
 	mkdir -p test/integration/providers
 	cp dist/provider_$(GOOS)_$(GOARCH_FULL)/terraform-provider-bindplane* test/integration/providers/terraform-provider-bindplane_v0.0.0
-	BINDPLANE_LICENSE=${BINDPLANE_LICENSE} bash test/integration/test.sh
+	BINDPLANE_VERSION=$(BINDPLANE_VERSION) BINDPLANE_LICENSE=${BINDPLANE_LICENSE} bash test/integration/test.sh
 
 # Test local configures test/local directory
 # with the provider.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ ALL_SRC := $(shell find . -name '*.go' -o -name '*.sh' -type f | sort)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+ifeq ($(BINDPLANE_VERSION), module)
 BINDPLANE_VERSION := $(shell go list -m all | grep github.com/observiq/bindplane-op-enterprise | awk '{print $$2}')
+endif
 
 ifeq ($(GOOS), windows)
 EXT?=.exe

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -261,6 +261,7 @@ func TestIntegration_invalidProtocol(t *testing.T) {
 		"BINDPLANE_SESSION_SECRET": "524abde2-d9f8-485c-b426-bac229686d13",
 		"BINDPLANE_SECRET_KEY":     "ED9B4232-C127-4580-9B86-62CEC420E7BB",
 		"BINDPLANE_LOGGING_OUTPUT": "stdout",
+		"BINDPLANE_ACCEPT_EULA":    "true",
 	}
 
 	container := bindplaneContainer(t, env)
@@ -297,6 +298,7 @@ func TestIntegration_https(t *testing.T) {
 		"BINDPLANE_SESSION_SECRET": "524abde2-d9f8-485c-b426-bac229686d13",
 		"BINDPLANE_SECRET_KEY":     "ED9B4232-C127-4580-9B86-62CEC420E7BB",
 		"BINDPLANE_LOGGING_OUTPUT": "stdout",
+		"BINDPLANE_ACCEPT_EULA":    "true",
 	}
 
 	container := bindplaneContainer(t, env)
@@ -337,6 +339,7 @@ func TestIntegration_https(t *testing.T) {
 // 		"BINDPLANE_SESSION_SECRET": "524abde2-d9f8-485c-b426-bac229686d13",
 // 		"BINDPLANE_SECRET_KEY":     "ED9B4232-C127-4580-9B86-62CEC420E7BB",
 // 		"BINDPLANE_LOGGING_OUTPUT": "stdout",
+//      "BINDPLANE_ACCEPT_EULA":    "true",
 // 	}
 
 // 	container := bindplaneContainer(t, env)
@@ -375,6 +378,7 @@ func TestIntegration_mtls(t *testing.T) {
 		"BINDPLANE_SESSION_SECRET": "524abde2-d9f8-485c-b426-bac229686d13",
 		"BINDPLANE_SECRET_KEY":     "ED9B4232-C127-4580-9B86-62CEC420E7BB",
 		"BINDPLANE_LOGGING_OUTPUT": "stdout",
+		"BINDPLANE_ACCEPT_EULA":    "true",
 	}
 
 	container := bindplaneContainer(t, env)

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -49,8 +49,13 @@ func bindplaneContainer(t *testing.T, env map[string]string) testcontainers.Cont
 	if version == "" {
 		t.Fatal("BINDPLANE_VERSION must be set: e.g. BINDPLANE_VERSION=v1.32.0")
 	}
-	tag := version[1:]
-	image := fmt.Sprintf("observiq/bindplane-ee:%s", tag)
+
+	// Trim the v prefix if not latest
+	if version != "latest" {
+		version = version[1:]
+	}
+
+	image := fmt.Sprintf("observiq/bindplane-ee:%s", version)
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 const (
-	bindplaneImage   = "observiq/bindplane:1.32.0"
 	bindplaneExtPort = 3100
 
 	username = "int-test-user"
@@ -45,6 +44,14 @@ const (
 )
 
 func bindplaneContainer(t *testing.T, env map[string]string) testcontainers.Container {
+	// Get the bindplane version to determine the image and tag
+	version := os.Getenv("BINDPLANE_VERSION")
+	if version == "" {
+		t.Fatal("BINDPLANE_VERSION must be set: e.g. BINDPLANE_VERSION=v1.32.0")
+	}
+	tag := version[1:]
+	image := fmt.Sprintf("observiq/bindplane-ee:%s", tag)
+
 	dir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +71,7 @@ func bindplaneContainer(t *testing.T, env map[string]string) testcontainers.Cont
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:  bindplaneImage,
+		Image:  image,
 		Env:    env,
 		Mounts: mounts,
 		// TODO(jsirianni): dynamic port?
@@ -91,6 +98,7 @@ func TestIntegration_http_config(t *testing.T) {
 		"BINDPLANE_SESSION_SECRET": "524abde2-d9f8-485c-b426-bac229686d13",
 		"BINDPLANE_SECRET_KEY":     "ED9B4232-C127-4580-9B86-62CEC420E7BB",
 		"BINDPLANE_LOGGING_OUTPUT": "stdout",
+		"BINDPLANE_ACCEPT_EULA":    "true",
 	}
 
 	container := bindplaneContainer(t, env)

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   bindplane:
     hostname: bindplane.bindplane-dev.svc.cluster.local
-    image: observiq/bindplane-ee:1.32.0
+    image: observiq/bindplane-ee:${BINDPLANE_VERSION}
     restart: always
     ports:
       - "3100:3001"

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - BINDPLANE_TLS_KEY=/bindplane.key
       - BINDPLANE_TLS_CA=/bindplane-ca.crt
       - BINDPLANE_REMOTE_URL=https://bindplane.bindplane-dev.svc.cluster.local:3001
-      - BINDPLANE_LICENSE=${BINDPLANE_LICENSE}
       - BINDPLANE_ACCEPT_EULA=true
     volumes:
       - "../../client/tls/bindplane.crt:/bindplane-ca.crt:ro"

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -57,11 +57,19 @@ destroy () {
 
 export TF_CLI_CONFIG_FILE=./dev.tfrc
 
+# fail if BINDPLANE_VERSION is not set
+if [[ -z $BINDPLANE_VERSION ]]; then
+    echo "BINDPLANE_VERSION is not set"
+    exit 1
+fi
+
 # trim the v prefix if not latest
 if [[ $BINDPLANE_VERSION != "latest" ]]; then
     BINDPLANE_VERSION=$(echo $BINDPLANE_VERSION | sed 's/^v//')
 fi
 export BINDPLANE_VERSION
+
+echo "using BINDPLANE_VERSION: ${BINDPLANE_VERSION}"
 
 start_containers
 sleep 10

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -57,11 +57,6 @@ destroy () {
 
 export TF_CLI_CONFIG_FILE=./dev.tfrc
 
-if [[ -z "$BINDPLANE_LICENSE" ]]; then
-    echo "Must provide BINDPLANE_LICENSE in environment" 1>&2
-    exit 1
-fi
-
 start_containers
 sleep 10
 apply

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -57,6 +57,9 @@ destroy () {
 
 export TF_CLI_CONFIG_FILE=./dev.tfrc
 
+# trim the v prefix
+export BINDPLANE_VERSION=$(echo $BINDPLANE_VERSION | sed 's/^v//')
+
 start_containers
 sleep 10
 apply

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -57,8 +57,11 @@ destroy () {
 
 export TF_CLI_CONFIG_FILE=./dev.tfrc
 
-# trim the v prefix
-export BINDPLANE_VERSION=$(echo $BINDPLANE_VERSION | sed 's/^v//')
+# trim the v prefix if not latest
+if [[ $BINDPLANE_VERSION != "latest" ]]; then
+    BINDPLANE_VERSION=$(echo $BINDPLANE_VERSION | sed 's/^v//')
+fi
+export BINDPLANE_VERSION
 
 start_containers
 sleep 10


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Updated integration and end to end tests to take a bindplane version as a parameter. This allows us to test latest, module (the current version in go.mod), and any other version.

This will ensure that we are testing against older versions, the version we are building against, and the "latest" version which is currently v1.34.

Also removed the use of BINDPLANE_LICENSE, as a license is no longer required to run EE edition.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
