### PR TITLE
fix: Processor ordering

### DIFF
--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -88,7 +88,7 @@ func resourceConfiguration() *schema.Resource {
 							Description: "Name of the source to attach.",
 						},
 						"processors": {
-							Type:        schema.TypeSet,
+							Type:        schema.TypeList,
 							Optional:    true,
 							ForceNew:    false,
 							Elem:        &schema.Schema{Type: schema.TypeString},
@@ -111,7 +111,7 @@ func resourceConfiguration() *schema.Resource {
 							Description: "Name of the destination to attach.",
 						},
 						"processors": {
-							Type:        schema.TypeSet,
+							Type:        schema.TypeList,
 							Optional:    true,
 							ForceNew:    false,
 							Elem:        &schema.Schema{Type: schema.TypeString},

--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -174,10 +174,8 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
 			sourcesRaw := v.(map[string]any)
 
 			processors := []string{}
-			if v := sourcesRaw["processors"].(*schema.Set); v != nil {
-				for _, processorName := range v.List() {
-					processors = append(processors, processorName.(string))
-				}
+			if v := sourcesRaw["processors"].([]string); v != nil {
+				processors = append(processors, v...)
 			}
 
 			sourceConf := configuration.ResourceConfig{
@@ -196,10 +194,8 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
 			destinationRaw := v.(map[string]any)
 
 			processors := []string{}
-			if v := destinationRaw["processors"].(*schema.Set); v != nil {
-				for _, processorName := range v.List() {
-					processors = append(processors, processorName.(string))
-				}
+			if v := destinationRaw["processors"].([]string); v != nil {
+				processors = append(processors, v...)
 			}
 
 			destConfig := configuration.ResourceConfig{

--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -174,8 +174,10 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
 			sourcesRaw := v.(map[string]any)
 
 			processors := []string{}
-			if v := sourcesRaw["processors"].([]string); v != nil {
-				processors = append(processors, v...)
+			if v := sourcesRaw["processors"].([]any); v != nil {
+				for _, v := range v {
+					processors = append(processors, v.(string))
+				}
 			}
 
 			sourceConf := configuration.ResourceConfig{
@@ -194,8 +196,10 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
 			destinationRaw := v.(map[string]any)
 
 			processors := []string{}
-			if v := destinationRaw["processors"].([]string); v != nil {
-				processors = append(processors, v...)
+			if v := destinationRaw["processors"].([]any); v != nil {
+				for _, v := range v {
+					processors = append(processors, v.(string))
+				}
 			}
 
 			destConfig := configuration.ResourceConfig{

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -20,7 +20,7 @@ resource "bindplane_source" "host" {
     [
       {
         "name": "collection_interval",
-        "value": 30
+        "value": 32
       },
       {
         "name": "enable_process",
@@ -36,10 +36,31 @@ resource "bindplane_source" "journald" {
   type = "journald"
 }
 
-resource "bindplane_destination" "google" {
+resource "bindplane_destination" "custom" {
   rollout = true
-  name = "my-google"
-  type = "googlecloud"
+  name = "example-custom"
+  type = "custom"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": [
+          "Metrics",
+          "Logs",
+          "Traces"
+        ]
+      },
+      {
+        "name": "configuration",
+        "value": <<EOT
+logging:
+  verbosity: detailed
+  sampling_initial: 5
+  sampling_thereafter: 200
+EOT
+      }
+    ]
+  )
 }
 
 resource "bindplane_processor" "add_fields" {
@@ -93,9 +114,134 @@ resource "bindplane_configuration" "configuration" {
 
 
   destination {
-    name = bindplane_destination.google.name
+    name = bindplane_destination.custom.name
     processors = [
-      bindplane_processor.batch.name
+      bindplane_processor.batch.name,
+
+      // order matters here
+      bindplane_processor.include-flog.name,
+      bindplane_processor.time-parse-http-datatime.name,
+      bindplane_processor.promoted-cleanup.name
     ]
   }
+}
+
+resource "bindplane_processor" "json-parse-body" {
+  rollout = false
+  name = "json-parse-body"
+  type = "parse_json"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "enable_logs",
+        "value": true
+      },
+      {
+        "name": "log_condition",
+        "value": "true"
+      },
+      {
+        "name": "log_source_field_type",
+        "value": "Body"
+      },
+      {
+        "name": "log_body_source_field",
+        "value": ""
+      },
+      {
+        "name": "log_target_field_type",
+        "value": "Body"
+      }
+    ]
+  )
+}
+
+resource "bindplane_processor" "promoted-cleanup" {
+  rollout = true
+  name = "promoted-cleanup"
+  type = "delete_fields"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "enable_logs",
+        "value": true
+      },
+      {
+        "name": "log_body_keys",
+        "value": [
+          "datetime"
+        ]
+      }
+    ]
+  )
+}
+
+resource "bindplane_processor" "include-flog" {
+  rollout = false
+  name = "include-flog"
+  type = "filter_field"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": [
+          "Metrics",
+          "Logs",
+          "Traces"
+        ]
+      },
+      {
+        "name": "action",
+        "value": "include"
+      },
+      {
+        "name": "match_type",
+        "value": "regexp"
+      },
+      {
+        "name": "bodies",
+        "value": {
+          "status": ".*"
+        }
+      }
+    ]
+  )
+}
+
+resource "bindplane_processor" "time-parse-http-datatime" {
+  rollout = false
+  name = "time-parse-http-datatime"
+  type = "parse_timestamp"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "enable_logs",
+        "value": true
+      },
+      {
+        "name": "log_condition",
+        "value": "body[\"datetime\"] != nil"
+      },
+      {
+        "name": "log_field_type",
+        "value": "Body"
+      },
+      {
+        "name": "log_source_field",
+        "value": "datetime"
+      },
+      {
+        "name": "log_time_format",
+        "value": "Manual"
+      },
+      {
+        "name": "log_epoch_layout",
+        "value": "s"
+      },
+      {
+        "name": "log_manual_timestamp_layout",
+        "value": "%d/%b/%Y:%H:%M:%S %z"
+      }
+    ]
+  )
 }


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Processor ordering can be guaranteed with TypeList. TypeList uses `[]any` as it's underlying type, but the Terraform schema guarantees that the values are `string` with the `Elem:        &schema.Schema{Type: schema.TypeString},` parameter. It is safe to assume that each value in `[]any` will be a string. You will see this all over in the provider, and any other provider.

You can read more about Terraform's schema types [here](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-types#typelist).

Before this change, processors would deploy out of order sometimes. For example, the test configuration has the following processors:

```tf
      bindplane_processor.batch.name,
      bindplane_processor.include-flog.name,
      bindplane_processor.time-parse-http-datatime.name,
      bindplane_processor.promoted-cleanup.name
```

They show up out of order

![Screenshot from 2023-11-29 16-21-25](https://github.com/observIQ/terraform-provider-bindplane/assets/23043836/3530dabd-4943-4f64-b1dc-8b78b143afe7)

After upgrading to this PR's provider, I get the following terraform output. It correctly detects the ordering mistake and wants to fix it.

```
  # bindplane_configuration.configuration will be updated in-place
  ~ resource "bindplane_configuration" "configuration" {
        id           = "01HGEFA20MQEDPYK6W28PYXFDM"
        name         = "my-config"
        # (4 unchanged attributes hidden)

      ~ destination {
            name       = "example-custom"
          ~ processors = [
              + "my-batch",
                "include-flog",
              - "promoted-cleanup",
                "time-parse-http-datatime",
              - "my-batch",
              + "promoted-cleanup",
            ]
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

After applying:

![Screenshot from 2023-11-29 16-21-58](https://github.com/observIQ/terraform-provider-bindplane/assets/23043836/da88e651-b908-4372-a91b-2d76d660674d)

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
