### PR TITLE
doc(lifecycle): Create before delete

### DIFF
--- a/docs/guides/common_issues.md
+++ b/docs/guides/common_issues.md
@@ -12,3 +12,50 @@ The provider cannot detect changes to sensitive values (credentials). If a chang
 not detect configuration drift.
 
 See the [Sensitive Values](/docs/guides/sensitive_values.md) documentation for more information.
+
+## Dependent Resources Error
+
+When removing a component from a configuration, Terraform may attempt to delete the component
+before updating the configuration. This can cause the following error:
+
+```
+╷
+│ Error: error while deleting destination with name example-custom: Dependent resources:
+│ Configuration my-config
+```
+
+This can be prevented by using the [lifecycle Meta-Argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle)
+[create_before_destroy](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy).
+
+```tf
+lifecycle {
+  create_before_destroy = true
+}
+```
+
+The create before destroy option will instruct Terraform to handle configuration updates before component deletion. This will result
+in the following order of operations:
+
+1. Remove the component from the configuration
+2. Delete the component
+
+
+```tf
+resource "bindplane_configuration" "simple" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  rollout = false
+  name = "example-configuration-simple"
+  platform = "linux"
+
+  source {
+    name = bindplane_source.host-custom.name
+  }
+
+  destination {
+    name = bindplane_destination.grafana.name
+  }
+}
+```

--- a/docs/resources/bindplane_configuration.md
+++ b/docs/resources/bindplane_configuration.md
@@ -115,6 +115,13 @@ resource "bindplane_processor" "batch" {
 }
 
 resource "bindplane_configuration" "configuration" {
+  // When removing a component from a configuration and deleting that
+  // component during the same apply, we want to update the configuration
+  // before the component is deleted.
+  lifecycle {
+    create_before_destroy = true
+  }
+
   rollout = true
   name = "my-config"
   platform = "linux"

--- a/example/configuration_full.tf
+++ b/example/configuration_full.tf
@@ -1,4 +1,11 @@
 resource "bindplane_configuration" "configuration-full" {
+  // When removing a component from a configuration and deleting that
+  // component during the same apply, we want to update the configuration
+  // before the component is deleted.
+  lifecycle {
+    create_before_destroy = true
+  }
+
   // Automatically rollout new versions of the configuration
   // to managed agents. This includes changes to the underlying
   // sources, processors, and destinations.

--- a/example/configuration_simple.tf
+++ b/example/configuration_simple.tf
@@ -1,4 +1,11 @@
 resource "bindplane_configuration" "configuration-simple" {
+  // When removing a component from a configuration and deleting that
+  // component during the same apply, we want to update the configuration
+  // before the component is deleted.
+  lifecycle {
+    create_before_destroy = true
+  }
+
   rollout = false
   name = "example-configuration-simple"
   platform = "linux"

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -24,6 +24,10 @@ provider "bindplane" {
 }
 
 resource "bindplane_configuration" "config" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
   rollout = true
   name = "testtf"
   platform = "linux"

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -90,6 +90,10 @@ resource "bindplane_processor" "batch" {
 }
 
 resource "bindplane_configuration" "configuration" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
   rollout = true
   name = "my-config"
   platform = "linux"


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Added documentation and examples of the lifecycle option "create_before_delete", which resolves an order of operations issue when removing a resource (such as a destination) from a config and deleting it in the same operation. We need Terraform to update the configuration before deleting the resource.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
