### PR TITLE
chore: Display embeded source type in terraform diff output

### DIFF
--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -94,6 +94,17 @@ func resourceConfiguration() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "List of processor names to attach to the source.",
 						},
+						// The provider does not support configuring embeded sources, however, it does
+						// handle detecting their type in order to make the diff output more clear.
+						// The provider will delete embeded sources if they are added to the configuration
+						// by the user, outside of Terraform.
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							ForceNew:    false,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The source type. This value is populated if an embeded source is detected within the configuration.",
+						},
 					},
 				},
 				Description: "Source name and list of processor names to attach to the configuration. This option can be configured one or many times.",
@@ -291,6 +302,9 @@ func resourceConfigurationRead(d *schema.ResourceData, meta any) error {
 	for _, s := range config.Spec.Sources {
 		source := map[string]any{}
 		source["name"] = strings.Split(s.Name, ":")[0]
+		if s.Type != "" {
+			source["type"] = s.Type
+		}
 		processors := []string{}
 		for _, p := range s.Processors {
 			processors = append(processors, strings.Split(p.Name, ":")[0])


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Terraform does not support embedded source types, but it will detect them if they appear due to configuration drift (user adding he source using the web ui).

If the user adds a source to the configuration using the UI, Terraform will detect and try to remove it. The output looks like this, and is missing the source's type. This can make it somewhat unclear.

```
Terraform will perform the following actions:

  # bindplane_configuration.configuration will be updated in-place
  ~ resource "bindplane_configuration" "configuration" {
        id           = "01HH5AQSTC9FCMK4J72S97QYHC"
        name         = "my-config"
        # (4 unchanged attributes hidden)

      - source {
          - processors = [] -> null
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

By adding the `type` parameter with `computed: true` to the configuration schema, we can set the type if it exists. This should only happen when the source is embedded within the configuration. The output will display the type, and make it more obvious which source Terraform wants to remove.

```
Terraform will perform the following actions:

  # bindplane_configuration.configuration will be updated in-place
  ~ resource "bindplane_configuration" "configuration" {
        id           = "01HH5AQSTC9FCMK4J72S97QYHC"
        name         = "my-config"
        # (4 unchanged attributes hidden)

      - source {
          - processors = [] -> null
          - type       = "host:1" -> null
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
