### PR TITLE
feat(resource): Support creating and deleting extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,9 +194,8 @@ jobs:
         bindplane_version:
           - "latest"
           - "module" # Use the current Go module version
-          - "v1.34.0"
-          - "v1.32.0"
-          - "v1.31.1"
+          - "v1.44.0"
+          - "v1.37.0" # Extension support added in v1.37.0
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -257,6 +257,22 @@ func TestIntegration_http_config(t *testing.T) {
 
 	_, err = i.GenericResource(model.KindAgent, "agent")
 	require.Error(t, err, "Generic get does not support agent")
+
+	extensionsResource := model.AnyResource{
+		ResourceMeta: model.ResourceMeta{
+			APIVersion: "bindplane.observiq.com/v1",
+			Kind:       "Extension",
+			Metadata: model.Metadata{
+				Name: "my-extension",
+			},
+		},
+		Spec: map[string]any{
+			"type": "pprof",
+		},
+	}
+
+	require.NoError(t, i.Apply(&extensionsResource, false), "did not expect error when creating extension")
+	require.NoError(t, i.Delete(model.KindExtension, "my-extension"), "did not expect error when deleting extension")
 }
 
 func TestIntegration_invalidProtocol(t *testing.T) {

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -267,7 +267,7 @@ func TestIntegration_http_config(t *testing.T) {
 			},
 		},
 		Spec: map[string]any{
-			"type": "pprof",
+			"type": "custom",
 		},
 	}
 

--- a/docs/resources/bindplane_extension.md
+++ b/docs/resources/bindplane_extension.md
@@ -1,0 +1,228 @@
+---
+subcategory: "Pipeline"
+description: |-
+  An Extension creates a BindPlane OP extension that can be attached
+  to a Configuration's sources or destinations.
+---
+
+# bindplane_extension
+
+The `bindplane_extension` resource creates a BindPlane extension from a BindPlane
+extension-type. The extension can be used by multiple [configurations](./bindplane_configuration.md).
+
+## Options
+
+| Option              | Type   | Default  | Description                  |
+| ------------------- | -----  | -------- | ---------------------------- |
+| `name`              | string | required | The extension name.          |
+| `type`              | string | required | The extension type.          |
+| `parameters_json`   | string | optional | The serialized JSON representation of the extension type's parameters. |
+| `rollout`           | bool   | required | Whether or not updates to the extension should trigger an automatic rollout of any configuration that uses it. |
+
+## Sensitive Values
+
+See the [sensitive values](./sensitive_values.md) doc for details related to Terraform's handling
+of sensitive parameters, such as passwords and API keys.
+
+## Examples
+
+### Go pprof w/ Default Options
+
+This example shows the [pprof](https://observiq.com/docs/agent-configuration/extensions/pprof) extension type
+with default parameters.
+
+```hcl
+resource "bindplane_extension" "pprof" {
+  rollout = true
+  name = "my-pprof"
+  type = "pprof"
+}
+```
+
+### Health Check w/ Custom Parameters
+
+This example shows the [health_check](https://observiq.com/docs/agent-configuration/extensions/health_check) extension type
+with custom parameters using the `parameters_json` option.
+
+```hcl
+resource "bindplane_extension" "health_check" {
+  rollout = true
+  name = "my-healthcheck"
+  type = "health_check"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "listen_address",
+        "value": "0.0.0.0"
+      },
+      {
+        "name": "listen_port",
+        "value": 8080,
+      },
+    ]
+  )
+}
+```
+
+## Usage
+
+You can find available extension types with the `bindplane get extension-type` command:
+```bash
+NAME        	DISPLAY                        	VERSION 
+custom      	Custom                         	1      	
+health_check	Health Check                   	2      	
+pprof       	Go Performance Profiler (pprof)	2   	
+```
+
+You can view an individual extension type's options with the `bindplane get extension-type <name> -o yaml` command:
+```yaml
+# bindplane get extension-type pprof -o yaml
+apiVersion: bindplane.observiq.com/v1
+kind: ExtensionType
+metadata:
+    id: 01HMC34DS83BXCV3ZACZB8EA1D
+    name: pprof
+    displayName: Go Performance Profiler (pprof)
+    description: Enable the Go performance profiler.
+    labels:
+        category: Advanced
+    version: 2
+spec:
+    version: 1.0.1
+    parameters:
+        - name: listen_address
+          label: Listen Address
+          description: The IP address or hostname to bind the profiler to.  Set to 0.0.0.0 to listen on all network interfaces.
+          required: true
+          type: string
+          default: 127.0.0.1
+        - name: tcp_port
+          label: Port
+          description: The TCP port to bind the profiler to.
+          required: true
+          type: int
+          default: 1777
+...
+```
+
+You can view the json representation of the extension type's options with the `-o json` flag combined with `jq`.
+For example, `bindplane get extension-type pprof -o json | jq .spec.parameters` produces the following:
+```json
+[
+  {
+    "name": "listen_address",
+    "label": "Listen Address",
+    "description": "The IP address or hostname to bind the profiler to.  Set to 0.0.0.0 to listen on all network interfaces.",
+    "required": true,
+    "type": "string",
+    "default": "127.0.0.1",
+    "options": {}
+  },
+  {
+    "name": "tcp_port",
+    "label": "Port",
+    "description": "The TCP port to bind the profiler to.",
+    "required": true,
+    "type": "int",
+    "default": 1777,
+    "options": {}
+  },
+  {
+    "name": "block_profile_fraction",
+    "label": "Block Profile Fraction",
+    "description": "The fraction of blocking events that are profiled.  Must be between 0 and 1.",
+    "type": "fraction",
+    "default": 0,
+    "advancedConfig": true,
+    "options": {}
+  },
+  {
+    "name": "mutex_profile_fraction",
+    "label": "Mutex Profile Fraction",
+    "description": "The fraction of mutex contention events that are profiled.  Must be between 0 and 1.",
+    "type": "fraction",
+    "default": 0,
+    "advancedConfig": true,
+    "options": {}
+  },
+  {
+    "name": "should_write_file",
+    "label": "Write CPU Profile to File",
+    "description": "Whether or not to write the CPU profile to a file.",
+    "type": "bool",
+    "default": false,
+    "advancedConfig": true,
+    "options": {
+      "sectionHeader": true
+    }
+  },
+  {
+    "name": "cpu_profile_file_name",
+    "label": "CPU Profile File Name",
+    "description": "The file name to write the CPU profile to.",
+    "required": true,
+    "type": "string",
+    "default": "$OIQ_OTEL_COLLECTOR_HOME/observiq-otel-collector.pprof",
+    "relevantIf": [
+      {
+        "name": "should_write_file",
+        "operator": "equals",
+        "value": true
+      }
+    ],
+    "advancedConfig": true,
+    "options": {}
+  }
+]
+```
+
+Use the JSON output as a reference when writing the `bindplane_extension` resource configuration. This example sets
+the `listen_address`, and `listen_port` for a `pprof` extension.
+
+```hcl
+resource "bindplane_extension" "pprof" {
+  rollout = true
+  name = "my-pprof"
+  type = "pprof"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "listen_address",
+        "value": "0.0.0.0"
+      },
+      {
+        "name": "tcp_port",
+        "value": 5000,
+      },
+    ]
+  )
+}
+```
+
+After applying the configuration with `terraform apply`, you can view the extension with
+the `bindplane get extension` commands.
+
+```bash
+NAME    	TYPE   	DESCRIPTION 
+my-pprof	pprof:1	  
+```
+```yaml
+# bindplane get extension my-pprof -o yaml
+apiVersion: bindplane.observiq.com/v1
+kind: Extension
+metadata:
+    id: 01HQNNG5JFCY74WQ4MAEVD61H7
+    name: my-pprof
+    hash: c83267fa3be1323c7733c4db79dba0c840eb4de91af3def6abc9103fc0ff2415
+    version: 1
+    dateModified: 2024-02-27T11:13:55.15176503-05:00
+spec:
+    type: pprof:1
+    parameters:
+        - name: listen_address
+          value: 0.0.0.0
+        - name: tcp_port
+          value: 5000
+status:
+    latest: true
+```

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -28,7 +28,7 @@ import (
 // AnyResourceFromConfigurationV1.
 func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Parameter) (model.AnyResource, error) {
 	switch rKind {
-	case model.KindSource, model.KindDestination, model.KindProcessor:
+	case model.KindSource, model.KindDestination, model.KindProcessor, model.KindExtension:
 		return model.AnyResource{
 			ResourceMeta: model.ResourceMeta{
 				APIVersion: "bindplane.observiq.com/v1",

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -69,6 +69,14 @@ func TestAnyResourceV1(t *testing.T) {
 			"",
 		},
 		{
+			"extension",
+			"my-extension",
+			"pprof",
+			model.KindExtension,
+			nil,
+			"",
+		},
+		{
 			"invalid-kind",
 			"my-resource",
 			"resource",

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -118,6 +118,7 @@ func Configure() *schema.Provider {
 			"bindplane_destination":   resourceDestination(),
 			"bindplane_source":        resourceSource(), // TODO(jsirianni): Determine if sources should be supported.
 			"bindplane_processor":     resourceProcessor(),
+			"bindplane_extension":     resourceExtension(),
 		},
 	}
 }

--- a/provider/resource_extension.go
+++ b/provider/resource_extension.go
@@ -1,0 +1,118 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/observiq/bindplane-op-enterprise/model"
+	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/parameter"
+	"github.com/observiq/terraform-provider-bindplane/internal/resource"
+)
+
+func resourceExtension() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceExtensionCreate,
+		Update: resourceExtensionCreate,
+		Read:   resourceExtensionRead,
+		Delete: resourceExtensionDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the extension.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    false,
+				Description: "The extension type to use for extension creation.",
+			},
+			"parameters_json": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "A JSON object with options used to configure the extension.",
+			},
+			"rollout": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    false,
+				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(maxTimeout),
+			Read:   schema.DefaultTimeout(maxTimeout),
+			Delete: schema.DefaultTimeout(maxTimeout),
+		},
+	}
+}
+
+func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
+	bindplane := meta.(*client.BindPlane)
+
+	destType := d.Get("type").(string)
+	name := d.Get("name").(string)
+	rollout := d.Get("rollout").(bool)
+
+	// If id is unset, it means Terraform has not previously created
+	// this resource. Check to ensure a resource with this name does
+	// not already exist.
+	if d.Id() == "" {
+		c, err := bindplane.Extension(name)
+		if err != nil {
+			return err
+		}
+		if c != nil {
+			return fmt.Errorf("extension with name '%s' already exists with id '%s'", name, c.ID())
+		}
+	}
+
+	parameters := []model.Parameter{}
+	if s := d.Get("parameters_json").(string); s != "" {
+		params, err := parameter.StringToParameter(s)
+		if err != nil {
+			return err
+		}
+		parameters = params
+	}
+
+	r, err := resource.AnyResourceV1(name, destType, model.KindExtension, parameters)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	timeout := d.Timeout(schema.TimeoutCreate) - time.Minute
+	if err := bindplane.ApplyWithRetry(ctx, timeout, &r, rollout); err != nil {
+		return err
+	}
+
+	return resourceExtensionRead(d, meta)
+}
+
+func resourceExtensionRead(d *schema.ResourceData, meta any) error {
+	return genericResourceRead(model.KindExtension, d, meta)
+}
+
+func resourceExtensionDelete(d *schema.ResourceData, meta any) error {
+	return genericResourceDelete(model.KindExtension, d, meta)
+}

--- a/provider/resource_extension.go
+++ b/provider/resource_extension.go
@@ -69,7 +69,7 @@ func resourceExtension() *schema.Resource {
 func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
 	bindplane := meta.(*client.BindPlane)
 
-	destType := d.Get("type").(string)
+	extensionType := d.Get("type").(string)
 	name := d.Get("name").(string)
 	rollout := d.Get("rollout").(bool)
 
@@ -95,7 +95,7 @@ func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, destType, model.KindExtension, parameters)
+	r, err := resource.AnyResourceV1(name, extensionType, model.KindExtension, parameters)
 	if err != nil {
 		return err
 	}

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -9,7 +9,7 @@ terraform {
 provider "bindplane" {
   remote_url = "http://localhost:3001"
   username = "admin"
-  password = "admin"
+  password = "password"
 }
 
 resource "bindplane_source" "host" {
@@ -246,6 +246,24 @@ resource "bindplane_processor" "time-parse-http-datatime" {
         "name": "log_manual_timestamp_layout",
         "value": "%d/%b/%Y:%H:%M:%S %z"
       }
+    ]
+  )
+}
+
+resource "bindplane_extension" "pprof" {
+  rollout = true
+  name = "my-pprof"
+  type = "pprof"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "listen_address",
+        "value": "0.0.0.0"
+      },
+      {
+        "name": "tcp_port",
+        "value": 5000,
+      },
     ]
   )
 }


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This PR introduces extensions to the provider. It **does not** add support for binding an extension to a configuration. This will be a follow up PR, to keep this PR's scope reasonable.

- Set CI min test version to 1.37.0, the version 
  - This version contained the `custom` extension
- Added `Extension()` and `DeleteExtension()` methods to `client` package. This follows the existing pattern for other resources.
- Added extension terraform resource `provider/resource_extension.go`

Extensions are very similar to the other resources, such as Destinations. It is basically a copy and paste + rename.

## Testing

Test cases have been added to all integration tests. If CI passes, you can be sure the extensions can be created and deleted.

Make sure you have Terraform installed.

1. Deploy bindplane locally with auth `admin` / `password`
2. Run `make test-local`
3. CD to `test/local/`
4. Run `TF_CLI_CONFIG_FILE=./dev.tfrc terraform apply`
5. Use CLI to check on your extension: `bindplane get extension`
```
NAME    	TYPE   	DESCRIPTION 
my-pprof	pprof:1	        
```
6. Run `TF_CLI_CONFIG_FILE=./dev.tfrc terraform destroy`
7. Ensure extension is no longer listed:  `bindplane get extension`

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
