### PR TITLE
feat(resource): Support attaching extensions to configurations

### DIFF
--- a/docs/resources/bindplane_configuration.md
+++ b/docs/resources/bindplane_configuration.md
@@ -115,6 +115,24 @@ resource "bindplane_processor" "batch" {
   type = "batch"
 }
 
+resource "bindplane_extension" "pprof" {
+  rollout = true
+  name = "my-pprof"
+  type = "pprof"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "listen_address",
+        "value": "0.0.0.0"
+      },
+      {
+        "name": "tcp_port",
+        "value": 5000,
+      },
+    ]
+  )
+}
+
 resource "bindplane_configuration" "configuration" {
   // When removing a component from a configuration and deleting that
   // component during the same apply, we want to update the configuration
@@ -151,5 +169,9 @@ resource "bindplane_configuration" "configuration" {
       bindplane_processor.batch.name
     ]
   }
+
+  extensions = [
+    bindplane_extension.pprof.name
+  ]
 }
 ```

--- a/docs/resources/bindplane_configuration.md
+++ b/docs/resources/bindplane_configuration.md
@@ -20,6 +20,7 @@ to one or more managed agents. Configurations are a combination of [sources](./b
 | `labels`       | map     | optional | Key value pairs representing labels to set on the configuration. |
 | `source`       | block   | optional | One or more source blocks. See the [source block](./bindplane_configuration.md#source-block) section. |
 | `destination`  | block   | optional | One or more destination blocks. See the [destination block](./bindplane_configuration.md#destination-block) section.
+| `extensions`   | list(string) | optional | One or more extension names to attach to the configuration. |
 | `rollout`      | bool    | required | Whether or not updates to the configuration should trigger an automatic rollout of the configuration. |
 
 ### Source Block

--- a/example/configuration_full.tf
+++ b/example/configuration_full.tf
@@ -68,4 +68,10 @@ resource "bindplane_configuration" "configuration-full" {
   destination {
     name = bindplane_destination.custom.name
   }
+
+  extensions = [
+    bindplane_extension.health_check.name,
+    bindplane_extension.pprof.name,
+    bindplane_extension.custom.name
+  ]
 }

--- a/example/extension_custom.tf
+++ b/example/extension_custom.tf
@@ -1,0 +1,17 @@
+resource "bindplane_extension" "custom" {
+  rollout = true
+  name = "example-custom"
+  type = "custom"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": ["Metrics", "Logs", "Traces"]
+      },
+      {
+        "name": "configuration",
+        "value": "health_check:"
+      }
+    ]
+  )
+}

--- a/example/extension_health_check.tf
+++ b/example/extension_health_check.tf
@@ -1,0 +1,17 @@
+resource "bindplane_extension" "health_check" {
+  rollout = true
+  name = "example-healthcheck"
+  type = "health_check"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "listen_address",
+        "value": "0.0.0.0"
+      },
+      {
+        "name": "listen_port",
+        "value": 8888,
+      },
+    ]
+  )
+}

--- a/example/extension_pprof.tf
+++ b/example/extension_pprof.tf
@@ -1,0 +1,17 @@
+resource "bindplane_extension" "pprof" {
+  rollout = true
+  name = "example-pprof"
+  type = "pprof"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "listen_address",
+        "value": "0.0.0.0"
+      },
+      {
+        "name": "tcp_port",
+        "value": 5000,
+      },
+    ]
+  )
+}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -77,6 +77,15 @@ func WithDestinationsByName(d []ResourceConfig) Option {
 	}
 }
 
+// WithExtensionsByName is a Option that configures a configuration's
+// extensions.
+func WithExtensionsByName(d []ResourceConfig) Option {
+	return func(c *model.Configuration) error {
+		c.Spec.Extensions = append(c.Spec.Extensions, withResourcesByName(d)...)
+		return nil
+	}
+}
+
 // WithMatchLabels is a Option that configures a configuration's
 // agent match labels.
 func WithMatchLabels(match map[string]string) Option {

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -135,6 +135,35 @@ func TestNewV1(t *testing.T) {
 			},
 		},
 		{
+			"extensions",
+			func() Option {
+				r := []ResourceConfig{
+					{
+						Name:       "test",
+						Processors: []string{},
+					},
+				}
+				return WithExtensionsByName(r)
+			}(),
+			&model.Configuration{
+				ResourceMeta: model.ResourceMeta{
+					APIVersion: "bindplane.observiq.com/v1",
+					Kind:       model.KindConfiguration,
+				},
+				Spec: model.ConfigurationSpec{
+					ContentType: "text/yaml",
+					Extensions: []model.ResourceConfiguration{
+						{
+							Name: "test",
+							ParameterizedSpec: model.ParameterizedSpec{
+								Processors: []model.ResourceConfiguration{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"labels",
 			func() Option {
 				labels := map[string]string{

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -60,6 +60,10 @@ func AnyResourceFromConfigurationV1(c *model.Configuration) model.AnyResource {
 		a.Spec["destinations"] = c.Spec.Destinations
 	}
 
+	if len(c.Spec.Extensions) > 0 {
+		a.Spec["extensions"] = c.Spec.Extensions
+	}
+
 	return a
 }
 

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -170,6 +170,11 @@ func TestAnyResourceFromConfigurationV1(t *testing.T) {
 							},
 						},
 					},
+					Extensions: []model.ResourceConfiguration{
+						{
+							Name: "pprof",
+						},
+					},
 				},
 			},
 			model.AnyResource{
@@ -212,6 +217,11 @@ func TestAnyResourceFromConfigurationV1(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+					"extensions": []model.ResourceConfiguration{
+						{
+							Name: "pprof",
 						},
 					},
 				},

--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -121,6 +121,13 @@ func resourceConfiguration() *schema.Resource {
 				},
 				Description: "Destination name and list of processor names to attach to the configuration. This option can be configured one or many times.",
 			},
+			"extensions": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    false,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of extensions names to attach to the configuration.",
+			},
 			"rollout": {
 				Type:        schema.TypeBool,
 				Required:    true,
@@ -210,12 +217,25 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta any) error {
 		}
 	}
 
+	// List of extensions represented as a list of configuration.ResourceConfig's
+	// with only the name field set.
+	extensions := []configuration.ResourceConfig{}
+	if e := d.Get("extensions").([]any); e != nil {
+		for _, extension := range e {
+			extensionConfig := configuration.ResourceConfig{
+				Name: extension.(string),
+			}
+			extensions = append(extensions, extensionConfig)
+		}
+	}
+
 	opts := []configuration.Option{
 		configuration.WithName(name),
 		configuration.WithLabels(labels),
 		configuration.WithMatchLabels(matchLabels),
 		configuration.WithSourcesByName(sources),
 		configuration.WithDestinationsByName(destinations),
+		configuration.WithExtensionsByName(extensions),
 	}
 
 	config, err := configuration.NewV1(opts...)

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -60,6 +60,10 @@ resource "bindplane_configuration" "config" {
   source {
     name = bindplane_source.host.name
   }
+
+  extensions = [
+    bindplane_extension.custom.name
+  ]
 }
 
 // Do not attach to test config. Will fail to startup
@@ -212,6 +216,24 @@ resource "bindplane_processor" "add_fields" {
         "value": {
           "key": "value2"
         }
+      }
+    ]
+  )
+}
+
+resource "bindplane_extension" "custom" {
+  rollout = true
+  name = "my-custom"
+  type = "custom"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": ["Metrics", "Logs", "Traces"]
+      },
+      {
+        "name": "configuration",
+        "value": "health_check:"
       }
     ]
   )

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -128,6 +128,10 @@ resource "bindplane_configuration" "configuration" {
       bindplane_processor.promoted-cleanup.name
     ]
   }
+
+  extensions = [
+    bindplane_extension.pprof.name
+  ]
 }
 
 resource "bindplane_processor" "json-parse-body" {


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Follow up PR for initial extension implementation: https://github.com/observIQ/terraform-provider-bindplane/pull/67

This PR adds a `extensions` option to the `bindplane_configuration` resource, allowing extensions to be attached to a configuration. It is identical to how processors are attached to `bindplane_source` and `bindplane_destination` resources. Its just a list of string values.

A majority of the changes are documentation and examples.

## Testing

Make sure you have Terraform installed.

1. Deploy bindplane locally with auth `admin` / `password`
2. Run `make test-local`
3. CD to `test/local/`
4. Run `TF_CLI_CONFIG_FILE=./dev.tfrc terraform apply`
5. Use CLI to check on your extension: `bindplane get config my-config -o json | jq .spec.extensions`
```json
[
  {
    "id": "01HQNYZHX88E2YV6CGWWDFF2M8",
    "name": "my-pprof:1"
  }
]        
```
6. Run `TF_CLI_CONFIG_FILE=./dev.tfrc terraform destroy`
7. Ensure extension and config are no longer listed
```bash
bindplane get config
bindplane get extension
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
