### PR TITLE
feat(bindplane_configuration): Support rollout options

### DIFF
--- a/docs/resources/bindplane_configuration.md
+++ b/docs/resources/bindplane_configuration.md
@@ -13,29 +13,44 @@ to one or more managed agents. Configurations are a combination of [sources](./b
 
 ## Options
 
-| Option         | Type    | Default  | Description                  |
-| -------------- | ------- | -------- | ---------------------------- |
-| `name`         | string  | required | The source name.             |
-| `platform`     | string  | required | The platform the configuration supports. See the [supported platforms](./bindplane_configuration.md#supported-platforms) section. |
-| `labels`       | map     | optional | Key value pairs representing labels to set on the configuration. |
-| `source`       | block   | optional | One or more source blocks. See the [source block](./bindplane_configuration.md#source-block) section. |
-| `destination`  | block   | optional | One or more destination blocks. See the [destination block](./bindplane_configuration.md#destination-block) section.
-| `extensions`   | list(string) | optional | One or more extension names to attach to the configuration. |
-| `rollout`      | bool    | required | Whether or not updates to the configuration should trigger an automatic rollout of the configuration. |
+| Option             | Type            | Default  | Description                                                                 |
+| ------------------ | --------------- | -------- | --------------------------------------------------------------------------- |
+| `name`             | string          | required | The source name.                                                            |
+| `platform`         | string          | required | The platform the configuration supports. See the [supported platforms](./bindplane_configuration.md#supported-platforms) section. |
+| `labels`           | map             | optional | Key value pairs representing labels to set on the configuration.            |
+| `source`           | block           | optional | One or more source blocks. See the [source block](./bindplane_configuration.md#source-block) section. |
+| `destination`      | block           | optional | One or more destination blocks. See the [destination block](./bindplane_configuration.md#destination-block) section. |
+| `extensions`       | list(string)    | optional | One or more extension names to attach to the configuration.                 |
+| `rollout`          | bool            | required | Whether or not updates to the configuration should trigger an automatic rollout of the configuration. |
+| `rollout_options`  | block (single)  | optional | Options for configuring the rollout behavior of the configuration. See the [rollout options block](./bindplane_configuration.md#rollout-options-block) section. |
 
 ### Source Block
 
 | Option              | Type         | Default  | Description                  |
-| ------------------- | -----------  | -------- | ---------------------------- |
+| ------------------- | ------------ | -------- | ---------------------------- |
 | `name`              | string       | required | The source name.             |
 | `processors`        | list(string) | optional | One or more processor names to attach to the source. |
 
 ### Destination Block
 
 | Option              | Type         | Default  | Description                  |
-| ------------------- | -----------  | -------- | ---------------------------- |
+| ------------------- | ------------ | -------- | ---------------------------- |
 | `name`              | string       | required | The source name.             |
 | `processors`        | list(string) | optional | One or more processor names to attach to the destination. |
+
+### Rollout Options Block
+
+| Option              | Type         | Default  | Description                  |
+| ------------------- | ------------ | -------- | ---------------------------- |
+| `type`              | string       | required | The type of rollout to perform. Valid values are 'standard' and 'progressive'. |
+| `parameters`        | list(block)  | optional | One or more parameters for the rollout. See the [parameters block](./bindplane_configuration.md#parameters-block) section. |
+
+### Parameters Block
+
+| Option              | Type         | Default  | Description                  |
+| ------------------- | ------------ | -------- | ---------------------------- |
+| `name`              | string       | required | The name of the parameter.   |
+| `value`             | any          | required | The value of the parameter.  |
 
 ### Supported Platforms
 
@@ -49,7 +64,7 @@ This table should be used as a reference for supported `platform` values.
 | Kubernetes DaemonSet   | `kubernetes-daemonset`  |
 | Kubernetes Deployment  | `kubernetes-deployment` |
 | OpenShift DaemonSet    | `openshift-daemonset`   |
-| OpenShift DaemonSet    | `openshift-deployment`  |
+| OpenShift Deployment   | `openshift-deployment`  |
 
 ## Examples
 
@@ -96,7 +111,7 @@ resource "bindplane_processor" "add_fields" {
   parameters_json = jsonencode(
     [
       {
-        "name": "enable_logs"
+        "name": "enable_logs",
         "value": true
       },
       {
@@ -128,7 +143,7 @@ resource "bindplane_extension" "pprof" {
       {
         "name": "tcp_port",
         "value": 5000,
-      },
+      }
     ]
   )
 }
@@ -173,5 +188,27 @@ resource "bindplane_configuration" "configuration" {
   extensions = [
     bindplane_extension.pprof.name
   ]
+
+  rollout_options {
+    type = "progressive"
+    parameters = [
+      {
+        name = "stages"
+        value = [
+          {
+            labels = {
+              env = "stage"
+            }
+            name = "stage"
+          },
+          {
+            labels = {
+              env = "production"
+            }
+            name = "production"
+          }
+        ]
+      }
+    ]
+  }
 }
-```

--- a/example/configuration_simple.tf
+++ b/example/configuration_simple.tf
@@ -17,4 +17,23 @@ resource "bindplane_configuration" "configuration-simple" {
   destination {
     name = bindplane_destination.grafana.name
   }
+
+  rollout_options {
+    type = "progressive"
+    parameters {
+      name = "stages"
+      value {
+        labels = {
+          env = "stage"
+        }
+        name = "stage"
+      }
+      value {
+        labels = {
+          env = "production"
+        }
+        name = "production"
+      }
+    }
+  }
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -95,6 +95,16 @@ func WithMatchLabels(match map[string]string) Option {
 	}
 }
 
+// WithRolloutOptions takes a model.ResourceConfiguration and returns
+// an Option that configures a configuration's rollout options. It is safe
+// to pass model.ResourceConfiguration's zero value to this function.
+func WithRolloutOptions(rolloutOptions model.ResourceConfiguration) Option {
+	return func(c *model.Configuration) error {
+		c.Spec.Rollout = rolloutOptions
+		return nil
+	}
+}
+
 // NewV1 takes configuration options and returns a BindPlane configuration
 func NewV1(options ...Option) (*model.Configuration, error) {
 	const (

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -64,6 +64,10 @@ func AnyResourceFromConfigurationV1(c *model.Configuration) model.AnyResource {
 		a.Spec["extensions"] = c.Spec.Extensions
 	}
 
+	if c.Spec.Rollout.Type != "" {
+		a.Spec["rollout"] = c.Spec.Rollout
+	}
+
 	return a
 }
 

--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -134,6 +134,55 @@ func resourceConfiguration() *schema.Resource {
 				ForceNew:    false,
 				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
 			},
+			"rollout_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    false,
+							Description: "The type of rollout to perform. Valid values are 'standard' and 'progressive'.",
+						},
+						"parameters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Name of the parameter.",
+									},
+									"value": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"labels": {
+													Type:        schema.TypeMap,
+													Required:    true,
+													Description: "Labels for the parameter.",
+												},
+												"name": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: "Name of the stage.",
+												},
+											},
+										},
+										Description: "Value of the parameter, which is a list of stages.",
+									},
+								},
+							},
+							Description: "List of parameters for the rollout options.",
+						},
+					},
+				},
+				Description: "Options for configuring the rollout behavior of the configuration.",
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(maxTimeout),

--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -437,6 +437,35 @@ func resourceConfigurationRead(d *schema.ResourceData, meta any) error {
 		return err
 	}
 
+	if err := resourceConfigurationRolloutOptionsRead(d, config.Spec.Rollout); err != nil {
+		return err
+	}
+
 	d.SetId(config.ID())
+	return nil
+}
+
+// resourceConfigurationRolloutOptionsRead takes a configuration's rollout options
+// and sets them in the Terraform state. This will trigger a terraform apply if the
+// rollout options have changed outside of Terraform.
+func resourceConfigurationRolloutOptionsRead(d *schema.ResourceData, rollout model.ResourceConfiguration) error {
+	rolloutOptions := make(map[string]interface{})
+
+	rolloutOptions["type"] = rollout.Type
+
+	parameters := make([]interface{}, len(rollout.Parameters))
+	for i, param := range rollout.Parameters {
+		parameters[i] = map[string]interface{}{
+			"name":  param.Name,
+			"value": param.Value,
+		}
+	}
+
+	rolloutOptions["parameters"] = parameters
+
+	if err := d.Set("rollout_options", []interface{}{rolloutOptions}); err != nil {
+		return fmt.Errorf("error setting rollout options: %s", err)
+	}
+
 	return nil
 }

--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -143,8 +143,15 @@ func resourceConfiguration() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:        schema.TypeString,
-							Required:    true,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(val any, _ string) (warns []string, errs []error) {
+								t := val.(string)
+								if t != "standard" && t != "progressive" {
+									errs = append(errs, fmt.Errorf("invalid rollout type: %s", t))
+								}
+								return
+							},
 							ForceNew:    false,
 							Description: "The type of rollout to perform. Valid values are 'standard' and 'progressive'.",
 						},

--- a/provider/resource_configuration_test.go
+++ b/provider/resource_configuration_test.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/observiq/bindplane-op-enterprise/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadRolloutOptions(t *testing.T) {
+	schemaMap := map[string]*schema.Schema{
+		"rollout_options": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"parameters": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"value": {
+									Type:     schema.TypeList,
+									Required: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"labels": {
+												Type:     schema.TypeMap,
+												Required: true,
+											},
+											"name": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, schemaMap, map[string]interface{}{
+		"rollout_options": []interface{}{
+			map[string]interface{}{
+				"type": "progressive",
+				"parameters": []interface{}{
+					map[string]interface{}{
+						"name": "stages",
+						"value": []interface{}{
+							map[string]interface{}{
+								"labels": map[string]interface{}{
+									"env": "stage",
+								},
+								"name": "stage",
+							},
+							map[string]interface{}{
+								"labels": map[string]interface{}{
+									"env": "production",
+								},
+								"name": "production",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	expected := model.ResourceConfiguration{
+		ParameterizedSpec: model.ParameterizedSpec{
+			Type: "progressive",
+			Parameters: []model.Parameter{
+				{
+					Name: "stages",
+					Value: []interface{}{
+						map[string]interface{}{
+							"labels": map[string]interface{}{
+								"env": "stage",
+							},
+							"name": "stage",
+						},
+						map[string]interface{}{
+							"labels": map[string]interface{}{
+								"env": "production",
+							},
+							"name": "production",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resourceConfig, err := readRolloutOptions(resourceData)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, resourceConfig)
+}
+
+func TestReadRolloutOptions_Empty(t *testing.T) {
+	schemaMap := map[string]*schema.Schema{
+		"rollout_options": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"parameters": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"value": {
+									Type:     schema.TypeList,
+									Required: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"labels": {
+												Type:     schema.TypeMap,
+												Required: true,
+											},
+											"name": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, schemaMap, map[string]interface{}{})
+
+	resourceConfig, err := readRolloutOptions(resourceData)
+	assert.NoError(t, err)
+	assert.Equal(t, resourceConfig, model.ResourceConfiguration{})
+}

--- a/provider/resource_configuration_test.go
+++ b/provider/resource_configuration_test.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package provider
 
 import (

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -29,6 +29,26 @@ resource "bindplane_configuration" "config" {
   }
 
   rollout = true
+
+  rollout_options {
+    type = "progressive"
+    parameters {
+      name = "stages"
+      value {
+        labels = {
+          env = "stage"
+        }
+        name = "stage"
+      }
+      value {
+        labels = {
+          env = "production"
+        }
+        name = "production"
+      }
+    }
+  }
+
   name = "testtf"
   platform = "linux"
   labels = {

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -7,9 +7,8 @@ terraform {
 }
 
 provider "bindplane" {
-  remote_url = "http://localhost:3001"
-  username = "admin"
-  password = "password"
+  remote_url = "https://saas.dev.bindplane.com"
+  api_key = "542b97b9-c4ac-42fc-b50a-6a1d3512d79e"
 }
 
 resource "bindplane_source" "host" {

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -99,6 +99,26 @@ resource "bindplane_configuration" "configuration" {
   }
 
   rollout = true
+
+  rollout_options {
+    type = "progressive"
+    parameters {
+      name = "stages"
+      value {
+        labels = {
+          env = "stage"
+        }
+        name = "stage"
+      }
+      value {
+        labels = {
+          env = "production"
+        }
+        name = "production"
+      }
+    }
+  }
+
   name = "my-config"
   platform = "linux"
   labels = {

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -7,8 +7,9 @@ terraform {
 }
 
 provider "bindplane" {
-  remote_url = "https://saas.dev.bindplane.com"
-  api_key = "542b97b9-c4ac-42fc-b50a-6a1d3512d79e"
+  remote_url = "http://localhost:3001"
+  username = "admin"
+  password = "password"
 }
 
 resource "bindplane_source" "host" {


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Implemented rollout options, for configuring the rollout behavior of a configuration. Default behavior is unchanged. When rollout options are not set, standard single stage rollouts are used.

The following snippet shows how a two stage progressive rollout can be configured.

```tf
resource "bindplane_configuration" "configuration-simple" {
...
  rollout_options {
    type = "progressive"
    parameters {
      name = "stages"
      value {
        labels = {
          env = "stage"
        }
        name = "stage"
      }
      value {
        labels = {
          env = "production"
        }
        name = "production"
      }
    }
  }
}
```

Changes
- Added `WithRolloutOptions` option function for setting rollout parameters on a configuration resource
- Updated `Configuration` to `AnyResource` conversion logic to consider the presence of `configuration.spec.rollout`

## Testing

You can test using the following steps
1. `make test-local`
2. `cd test/local`
3. `export TF_CLI_CONFIG_FILE=./dev.tfrc`
4. `Update `main.tf` provider block to target your environment (user/pass, api key, endpoint, etc)
5. `terraform apply`

Play around with `main.tf`'s `bindplane_configuration`. The following should work
1. Removal of the rollout_options
2. `standard` rollout type, without parameters
3. `progressive` rollout type, with parameters
4. Changes to `main.tf` should cause `apply` to update bindplane
5. Changes to the configuration (via the UI) should cause `apply` to update bindplane
6. Try feeding jump data for name and value, bindplane api should return errors if something is not compatible
7. Removing rollout options should result in the rollout reverting to "standard"

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
