### PR TITLE
fix(import): Destination import should use model.KindDestination

### DIFF
--- a/provider/resource_destination.go
+++ b/provider/resource_destination.go
@@ -121,5 +121,5 @@ func resourceDestinationDelete(d *schema.ResourceData, meta any) error {
 }
 
 func resourceDestinationImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	return genericResourceImport(model.KindProcessor, d, meta)
+	return genericResourceImport(model.KindDestination, d, meta)
 }


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

When importing a destination, a failure will occur with an error looking up a processor. This is because the import logic looks for processors instead of destinations.

## Testing

1. `make test-local`
2. `cd test/local`
3. `export TF_CLI_CONFIG_FILE=./dev.tfrc`
4. Update `main.tf` to use saas and an api key against a new project with no resources
5. `terraform apply`, create all resources
6. Delete destination from state `terraform state rm bindplane_destination.custom`
7. Re-run `apply` and note the correct failure, "already exists" (because it does!)

Import the destination.

```bash
terraform import bindplane_destination.custom example-custom
```
```
bindplane_destination.custom: Importing from ID "example-custom"...
bindplane_destination.custom: Import prepared!
  Prepared bindplane_destination for import
bindplane_destination.custom: Refreshing state... [id=example-custom]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

The destination was imported correctly. You can re-run `apply` for the third time and it will suggest a small change, which will succeed.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
