### PR TITLE
fix(bindplane_configuration): Lack of rollout options should not cause a change during apply

### DIFF
--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -477,6 +477,10 @@ func resourceConfigurationRead(d *schema.ResourceData, meta any) error {
 // and sets them in the Terraform state. This will trigger a terraform apply if the
 // rollout options have changed outside of Terraform.
 func resourceConfigurationRolloutOptionsRead(d *schema.ResourceData, rollout model.ResourceConfiguration) error {
+	if len(rollout.Parameters) == 0 {
+		return nil
+	}
+
 	rolloutOptions := make(map[string]interface{})
 
 	rolloutOptions["type"] = rollout.Type


### PR DESCRIPTION


<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Resolves https://github.com/observIQ/terraform-provider-bindplane/issues/106

During Terraform `plan` | `apply`, configuration resources will attempt to make the following change when `rollout_options` are not specified.

```
Terraform will perform the following actions:

  # bindplane_configuration.configuration will be updated in-place
  ~ resource "bindplane_configuration" "configuration" {
        id                   = "01J4QENC1ZFCZ4A636AETS1990"
        name                 = "my-config"
        # (6 unchanged attributes hidden)

      - rollout_options {
            # (1 unchanged attribute hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Testing

Rollout options should be idempotent when no changes have been made. Test adding, removing, and modifying rollout options. Repeat applies should not suggest changes unless something has changed.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
