### PR TITLE
feat: Support resource display name and description metadata fields

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -237,12 +237,13 @@ func (i *BindPlane) Delete(k model.Kind, name string) error {
 }
 
 // GenericResource represents a BindPlane resource's
-// id, name, version, and ParameterizedSpec.
+// id, name, version, metadata and ParameterizedSpec.
 type GenericResource struct {
-	ID      string
-	Name    string
-	Version model.Version
-	Spec    model.ParameterizedSpec
+	ID       string
+	Name     string
+	Version  model.Version
+	Metadata model.Metadata
+	Spec     model.ParameterizedSpec
 }
 
 // GenericResource looks up a BindPlane resource and returns a GenericResource.
@@ -265,6 +266,7 @@ func (i *BindPlane) GenericResource(k model.Kind, name string) (*GenericResource
 		g.ID = r.ID()
 		g.Name = r.Name()
 		g.Version = r.Version()
+		g.Metadata = r.Metadata
 		g.Spec = r.Spec
 	case model.KindSource:
 		r, err := i.Source(name)
@@ -279,6 +281,7 @@ func (i *BindPlane) GenericResource(k model.Kind, name string) (*GenericResource
 		g.ID = r.ID()
 		g.Name = r.Name()
 		g.Version = r.Version()
+		g.Metadata = r.Metadata
 		g.Spec = r.Spec
 	case model.KindProcessor:
 		r, err := i.Processor(name)
@@ -293,6 +296,7 @@ func (i *BindPlane) GenericResource(k model.Kind, name string) (*GenericResource
 		g.ID = r.ID()
 		g.Name = r.Name()
 		g.Version = r.Version()
+		g.Metadata = r.Metadata
 		g.Spec = r.Spec
 	case model.KindExtension:
 		r, err := i.Extension(name)
@@ -307,6 +311,7 @@ func (i *BindPlane) GenericResource(k model.Kind, name string) (*GenericResource
 		g.ID = r.ID()
 		g.Name = r.Name()
 		g.Version = r.Version()
+		g.Metadata = r.Metadata
 		g.Spec = r.Spec
 	default:
 		return nil, fmt.Errorf("GenericResource does not support bindplane kind '%s'", k)

--- a/docs/resources/bindplane_destination.md
+++ b/docs/resources/bindplane_destination.md
@@ -19,6 +19,8 @@ destination-type. The destination can be used by multiple [configurations](./bin
 | `type`              | string | required | The destination type.             |
 | `parameters_json`   | string | optional | The serialized JSON representation of the destination type's parameters. |
 | `rollout`           | bool   | required | Whether or not updates to the destination should trigger an automatic rollout of any configuration that uses it. |
+| `display_name`      | string | optional | The display name which will be set on the resources `metadata.displayName` field. |
+| `description`       | string | optional | The description which will be set on the resources `metadata.description` field.  |
 
 ## Sensitive Values
 

--- a/docs/resources/bindplane_extension.md
+++ b/docs/resources/bindplane_extension.md
@@ -18,6 +18,8 @@ extension-type. The extension can be used by multiple [configurations](./bindpla
 | `type`              | string | required | The extension type.          |
 | `parameters_json`   | string | optional | The serialized JSON representation of the extension type's parameters. |
 | `rollout`           | bool   | required | Whether or not updates to the extension should trigger an automatic rollout of any configuration that uses it. |
+| `display_name`      | string | optional | The display name which will be set on the resources `metadata.displayName` field. |
+| `description`       | string | optional | The description which will be set on the resources `metadata.description` field.  |
 
 ## Sensitive Values
 

--- a/docs/resources/bindplane_processor.md
+++ b/docs/resources/bindplane_processor.md
@@ -18,6 +18,8 @@ processor-type. The processor can be used by multiple [configurations](./bindpla
 | `type`              | string | required | The processor type.             |
 | `parameters_json`   | string | optional | The serialized JSON representation of the processor type's parameters. |
 | `rollout`           | bool   | required | Whether or not updates to the processor should trigger an automatic rollout of any configuration that uses it. |
+| `display_name`      | string | optional | The display name which will be set on the resources `metadata.displayName` field. |
+| `description`       | string | optional | The description which will be set on the resources `metadata.description` field.  |
 
 ## Sensitive Values
 

--- a/docs/resources/bindplane_source.md
+++ b/docs/resources/bindplane_source.md
@@ -19,6 +19,8 @@ source-type. The source can be used by multiple [configurations](./bindplane_con
 | `type`              | string | required | The source type.             |
 | `parameters_json`   | string | optional | The serialized JSON representation of the source type's parameters. |
 | `rollout`           | bool   | required | Whether or not updates to the source should trigger an automatic rollout of any configuration that uses it. |
+| `display_name`      | string | optional | The display name which will be set on the resources `metadata.displayName` field. |
+| `description`       | string | optional | The description which will be set on the resources `metadata.description` field.  |
 
 ## Sensitive Values
 

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -22,14 +22,14 @@ import (
 	"github.com/observiq/bindplane-op-enterprise/model"
 )
 
-// AnyResourceV1 takes a BindPlane resource name, kind, type, parameters
-// and returns a bindplane.observiq.com/v1.AnyResource. Supported resources
-// are Sources, Destinations, and Processors. For configurations, use
+// AnyResourceV1 requires a BindPlane resource name, kind, type, and parameters. Optionally
+// takes a display name and description. Returns a bindplane.observiq.com/v1.AnyResource.
+// Supported resources are Sources, Destinations, and Processors. For configurations, use
 // AnyResourceFromConfigurationV1.
-func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Parameter) (model.AnyResource, error) {
+func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Parameter, displayName, description string) (model.AnyResource, error) {
 	switch rKind {
 	case model.KindSource, model.KindDestination, model.KindProcessor, model.KindExtension:
-		return model.AnyResource{
+		r := model.AnyResource{
 			ResourceMeta: model.ResourceMeta{
 				APIVersion: "bindplane.observiq.com/v1",
 				Kind:       rKind,
@@ -41,7 +41,17 @@ func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Pa
 				"type":       rType,
 				"parameters": rParameters,
 			},
-		}, nil
+		}
+
+		if displayName != "" {
+			r.Metadata.DisplayName = displayName
+		}
+
+		if description != "" {
+			r.Metadata.Description = description
+		}
+
+		return r, nil
 	default:
 		return model.AnyResource{}, fmt.Errorf("unknown bindplane resource kind: %s", rKind)
 	}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -88,7 +88,7 @@ func TestAnyResourceV1(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters)
+			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters, "", "")
 			if tc.expectErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.expectErr)

--- a/provider/resource_destination.go
+++ b/provider/resource_destination.go
@@ -60,6 +60,8 @@ func resourceDestination() *schema.Resource {
 				ForceNew:    false,
 				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
 			},
+			"display_name": genericSchemaDisplayName(),
+			"description":  genericSchemaDescription(),
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(maxTimeout),
@@ -98,7 +100,17 @@ func resourceDestinationCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, destType, model.KindDestination, parameters)
+	displayName := ""
+	if v := d.Get("display_name").(string); v != "" {
+		displayName = v
+	}
+
+	description := ""
+	if v := d.Get("description").(string); v != "" {
+		description = v
+	}
+
+	r, err := resource.AnyResourceV1(name, destType, model.KindDestination, parameters, displayName, description)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_extension.go
+++ b/provider/resource_extension.go
@@ -60,6 +60,8 @@ func resourceExtension() *schema.Resource {
 				ForceNew:    false,
 				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
 			},
+			"display_name": genericSchemaDisplayName(),
+			"description":  genericSchemaDescription(),
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(maxTimeout),
@@ -98,7 +100,17 @@ func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, extensionType, model.KindExtension, parameters)
+	displayName := ""
+	if v := d.Get("display_name").(string); v != "" {
+		displayName = v
+	}
+
+	description := ""
+	if v := d.Get("description").(string); v != "" {
+		description = v
+	}
+
+	r, err := resource.AnyResourceV1(name, extensionType, model.KindExtension, parameters, displayName, description)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_generic.go
+++ b/provider/resource_generic.go
@@ -66,6 +66,18 @@ func genericResourceRead(rKind model.Kind, d *schema.ResourceData, meta any) err
 		return err
 	}
 
+	if g.Metadata.DisplayName != "" {
+		if err := d.Set("display_name", g.Metadata.DisplayName); err != nil {
+			return err
+		}
+	}
+
+	if g.Metadata.Description != "" {
+		if err := d.Set("description", g.Metadata.Description); err != nil {
+			return err
+		}
+	}
+
 	rType := strings.Split(g.Spec.Type, ":")[0]
 	if err := d.Set("type", rType); err != nil {
 		return err
@@ -144,4 +156,22 @@ func genericResourceImport(rKind model.Kind, d *schema.ResourceData, meta any) (
 	}
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func genericSchemaDisplayName() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		ForceNew:    false,
+		Description: "The display name of the component.",
+	}
+}
+
+func genericSchemaDescription() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		ForceNew:    false,
+		Description: "The description of the component.",
+	}
 }

--- a/provider/resource_processor.go
+++ b/provider/resource_processor.go
@@ -60,6 +60,8 @@ func resourceProcessor() *schema.Resource {
 				ForceNew:    false,
 				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
 			},
+			"display_name": genericSchemaDisplayName(),
+			"description":  genericSchemaDescription(),
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(maxTimeout),
@@ -98,7 +100,17 @@ func resourceProcessorCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, parameters)
+	displayName := ""
+	if v := d.Get("display_name").(string); v != "" {
+		displayName = v
+	}
+
+	description := ""
+	if v := d.Get("description").(string); v != "" {
+		description = v
+	}
+
+	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, parameters, displayName, description)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_source.go
+++ b/provider/resource_source.go
@@ -61,6 +61,8 @@ func resourceSource() *schema.Resource {
 				ForceNew:    false,
 				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
 			},
+			"display_name": genericSchemaDisplayName(),
+			"description":  genericSchemaDescription(),
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(maxTimeout),
@@ -99,7 +101,17 @@ func resourceSourceCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, sourceType, model.KindSource, parameters)
+	displayName := ""
+	if v := d.Get("display_name").(string); v != "" {
+		displayName = v
+	}
+
+	description := ""
+	if v := d.Get("description").(string); v != "" {
+		description = v
+	}
+
+	r, err := resource.AnyResourceV1(name, sourceType, model.KindSource, parameters, displayName, description)
 	if err != nil {
 		return err
 	}

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -95,6 +95,8 @@ resource "bindplane_destination" "google_dest" {
   rollout = true
   name = "google-test"
   type = "googlecloud"
+  display_name = "my host"
+  description = "my terraform description"
   parameters_json = jsonencode(
     [
       {

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -16,6 +16,8 @@ resource "bindplane_source" "host" {
   rollout = true
   name = "my-host"
   type = "host"
+  display_name = "my host"
+  description = "my terraform description"
   parameters_json = jsonencode(
     [
       {


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This PR depends on some pending BindPlane changes, and will not work as expected against current versions of BindPlane. This PR will remain in a draft state until the BindPlane changes are in place.

Added `display_name` and `description` parameters for components (sources, processors, destinations, extensions). The params behave the same for all four resource types, so I tried to make them as generic as possible.

Resolves https://github.com/observIQ/terraform-provider-bindplane/issues/109
Resolves https://github.com/observIQ/terraform-provider-bindplane/issues/107

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
