### PR TITLE
fix(bindplane_configuration): Read configuration extensions into state

### DIFF
--- a/provider/resource_configuration.go
+++ b/provider/resource_configuration.go
@@ -460,6 +460,14 @@ func resourceConfigurationRead(d *schema.ResourceData, meta any) error {
 		return err
 	}
 
+	extensions := []string{}
+	for _, e := range config.Spec.Extensions {
+		extensions = append(extensions, strings.Split(e.Name, ":")[0])
+	}
+	if err := d.Set("extensions", extensions); err != nil {
+		return err
+	}
+
 	if err := resourceConfigurationRolloutOptionsRead(d, config.Spec.Rollout); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Resolves an issue where Terraform does not detect if extensions were added to a configuration, outside of Terraform.

The read function for `bindplane_configuration` resources is not reading extensions into the state, therefore, BindPlane will not detect configuration drift for extensions.

## Testing

### Re-produce issue

Checkout `main` and run `make test-local`. Switch to `test/local` and run `export TF_CLI_CONFIG_FILE=./dev.tfrc`. Update `main.tf` to point to your BindPlane instance.

Run `terraform apply` to deploy the resources.

Using the UI, modify the configuration `my-config` to include a new extension. When you re-run Terraform, it **will not** detect the new extension.

### Test

Re-run `make test-local`. Terraform plan and apply will now detect drift in the extension list.

```
Terraform will perform the following actions:

  # bindplane_configuration.configuration will be updated in-place
  ~ resource "bindplane_configuration" "configuration" {
      ~ extensions           = [
            "my-pprof",
          - null,
        ]
        id                   = "01J4WWY6TVZHQRF1CS9PVR6DN4"
        name                 = "my-config"
        # (5 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The extension `null` is expected here, because the extension is embedded and does not contain a name (this is how resources are handled when not created by Terraform or added to the resource library).

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
