### PR TITLE
feat(resource): Processor Bundles

### DIFF
--- a/docs/resources/bindplane_processor_bundles.md
+++ b/docs/resources/bindplane_processor_bundles.md
@@ -1,0 +1,116 @@
+---
+subcategory: "Pipeline"
+description: |-
+  A Processor Bundle creates a BindPlane OP processor bundle that can be attached
+  to a Configuration's sources or destinations.
+---
+
+# bindplane_processor
+
+The `bindplane_processor_bundle` resource creates a [BindPlane Processor Bundle](https://bindplane.com/docs/feature-guides/processor-bundles)
+The processor bundle can be used by multiple [configurations](./bindplane_configuration.md).
+
+## Options
+
+| Option              | Type   | Default  | Description                  |
+| ------------------- | -----  | -------- | ---------------------------- |
+| `name`              | string | required | The processor name.             |
+| `processor`         | processor block | required | One or more processor blocks. |
+| `rollout`           | bool   | required | Whether or not updates to the processor should trigger an automatic rollout of any configuration that uses it. |
+
+Processor block supports the following:
+
+| Option             | Type   | Default  | Description                  |
+| ------------------ | -----  | -------- | ---------------------------- |
+| `name`             | string | required | The name of the processor to include in the bundle. |
+
+## Usage
+
+This example shows how to combine the batch and json processors
+into a processor bundle.
+
+```hcl
+resource "bindplane_processor" "json-parse-body" {
+  rollout = false
+  name = "json-parse-body"
+  type = "parse_json"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": [
+          "Logs",
+        ]
+      },
+      {
+        "name": "log_source_field_type",
+        "value": "Body"
+      },
+      {
+        "name": "log_body_source_field",
+        "value": ""
+      },
+      {
+        "name": "log_target_field_type",
+        "value": "Body"
+      }
+    ]
+  )
+}
+
+resource "bindplane_processor" "batch" {
+  rollout = false
+  name    = "example-batch"
+  type    = "batch"
+}
+
+resource "bindplane_processor_bundle" "bundle" {
+  rollout = true
+  name = "my-bundle"
+
+  processor {
+    name = bindplane_processor.json-parse-body.name
+  }
+
+  processor {
+    name = bindplane_processor.batch.name
+  }
+}
+```
+
+After applying the configuration with `terraform apply`, you can view the processor bundle with
+the `bindplane get processor "my-bundle"` command.
+
+```bash
+NAME     	TYPE 
+my-bundle	processor_bundle:1
+```
+```yaml
+# bindplane get processor my-bundle -o yaml
+apiVersion: bindplane.observiq.com/v1
+kind: Processor
+metadata:
+    id: 01JKEX6ZZNHHNX171N8JKQC57M
+    name: my-bundle
+    hash: 5ee0be3c33158b0452bf77da9413c4a571c2b9c407a2b84481741067c7c962b8
+    version: 1
+    dateModified: 2025-02-06T19:33:33.191627322-05:00
+spec:
+    type: processor_bundle:1
+    processors:
+        - id: p-example-batch
+          name: example-batch:1
+        - id: p-json-parse-body
+          name: json-parse-body:1
+status:
+    latest: true
+```
+
+## Import
+
+When using the [terraform import command](https://developer.hashicorp.com/terraform/cli/commands/import),
+processor bundles can be imported. For example:
+
+```bash
+terraform import bindplane_processor_bundle.bundle {{name}}
+```

--- a/example/processor_batch.tf
+++ b/example/processor_batch.tf
@@ -2,21 +2,5 @@ resource "bindplane_processor" "batch" {
   rollout = false
   name    = "example-batch"
   type    = "batch"
-  parameters_json = jsonencode(
-    [
-      {
-        "name" : "send_batch_size",
-        "value" : 200
-      },
-      {
-        "name" : "send_batch_max_size",
-        "value" : 400
-      },
-      {
-        "name" : "timeout",
-        "value" : "2s"
-      }
-    ]
-  )
 }
 

--- a/example/processor_batch.tf
+++ b/example/processor_batch.tf
@@ -2,5 +2,21 @@ resource "bindplane_processor" "batch" {
   rollout = false
   name    = "example-batch"
   type    = "batch"
+  parameters_json = jsonencode(
+    [
+      {
+        "name" : "send_batch_size",
+        "value" : 200
+      },
+      {
+        "name" : "send_batch_max_size",
+        "value" : 400
+      },
+      {
+        "name" : "timeout",
+        "value" : "2s"
+      }
+    ]
+  )
 }
 

--- a/example/processor_bundle.tf
+++ b/example/processor_bundle.tf
@@ -1,0 +1,12 @@
+resource "bindplane_processor_bundle" "bundle" {
+  rollout = true
+  name = "my-bundle"
+
+  processor {
+    name = bindplane_processor.custom.name
+  }
+
+  processor {
+    name = bindplane_processor.batch.name
+  }
+}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -23,13 +23,26 @@ import (
 )
 
 // AnyResourceV1 takes a BindPlane resource name, kind, type, parameters
-// and returns a bindplane.observiq.com/v1.AnyResource. Supported resources
-// are Sources, Destinations, and Processors. For configurations, use
-// AnyResourceFromConfigurationV1.
-func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Parameter) (model.AnyResource, error) {
+// and processors and returns a bindplane.observiq.com/v1.AnyResource.
+// Supported resources are Sources, Destinations, and Processors. For
+// configurations, use AnyResourceFromConfigurationV1.
+//
+// rParameters and rProcessors can be nil.
+func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Parameter, rProcessors []model.ResourceConfiguration) (model.AnyResource, error) {
+	procs := []map[string]string{}
+	for _, p := range rProcessors {
+		proc := map[string]string{}
+
+		if p.Name != "" {
+			proc["name"] = p.Name
+		}
+
+		procs = append(procs, proc)
+	}
+
 	switch rKind {
 	case model.KindSource, model.KindDestination, model.KindProcessor, model.KindExtension:
-		return model.AnyResource{
+		r := model.AnyResource{
 			ResourceMeta: model.ResourceMeta{
 				APIVersion: "bindplane.observiq.com/v1",
 				Kind:       rKind,
@@ -40,8 +53,10 @@ func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Pa
 			Spec: map[string]any{
 				"type":       rType,
 				"parameters": rParameters,
+				"processors": procs,
 			},
-		}, nil
+		}
+		return r, nil
 	default:
 		return model.AnyResource{}, fmt.Errorf("unknown bindplane resource kind: %s", rKind)
 	}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -42,7 +42,7 @@ func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Pa
 
 	switch rKind {
 	case model.KindSource, model.KindDestination, model.KindProcessor, model.KindExtension:
-		r := model.AnyResource{
+		return model.AnyResource{
 			ResourceMeta: model.ResourceMeta{
 				APIVersion: "bindplane.observiq.com/v1",
 				Kind:       rKind,
@@ -55,8 +55,7 @@ func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Pa
 				"parameters": rParameters,
 				"processors": procs,
 			},
-		}
-		return r, nil
+		}, nil
 	default:
 		return model.AnyResource{}, fmt.Errorf("unknown bindplane resource kind: %s", rKind)
 	}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -28,7 +28,7 @@ func TestAnyResourceV1(t *testing.T) {
 		rType       string
 		rkind       model.Kind
 		rParameters []model.Parameter
-		rProcessors []model.Processor
+		rProcessors []model.ResourceConfiguration
 		expectErr   string
 	}{
 		{
@@ -90,11 +90,27 @@ func TestAnyResourceV1(t *testing.T) {
 			nil,
 			"unknown bindplane resource kind: Agent",
 		},
+		{
+			"valid-processors",
+			"my-bundle",
+			"bundle",
+			model.KindProcessor,
+			nil,
+			[]model.ResourceConfiguration{
+				{
+					Name: "filter-a",
+				},
+				{
+					Name: "filter-b",
+				},
+			},
+			"",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters, nil)
+			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters, tc.rProcessors)
 			if tc.expectErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.expectErr)

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -28,6 +28,7 @@ func TestAnyResourceV1(t *testing.T) {
 		rType       string
 		rkind       model.Kind
 		rParameters []model.Parameter
+		rProcessors []model.Processor
 		expectErr   string
 	}{
 		{
@@ -45,6 +46,7 @@ func TestAnyResourceV1(t *testing.T) {
 					Value: []string{"test"},
 				},
 			},
+			nil,
 			"",
 		},
 		{
@@ -58,6 +60,7 @@ func TestAnyResourceV1(t *testing.T) {
 					Value: "my-project",
 				},
 			},
+			nil,
 			"",
 		},
 		{
@@ -65,6 +68,7 @@ func TestAnyResourceV1(t *testing.T) {
 			"my-filter",
 			"filter",
 			model.KindProcessor,
+			nil,
 			nil,
 			"",
 		},
@@ -74,6 +78,7 @@ func TestAnyResourceV1(t *testing.T) {
 			"pprof",
 			model.KindExtension,
 			nil,
+			nil,
 			"",
 		},
 		{
@@ -82,13 +87,14 @@ func TestAnyResourceV1(t *testing.T) {
 			"resource",
 			model.KindAgent,
 			nil,
+			nil,
 			"unknown bindplane resource kind: Agent",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters)
+			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters, nil)
 			if tc.expectErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.expectErr)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -114,11 +114,12 @@ func Configure() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"bindplane_configuration": resourceConfiguration(),
-			"bindplane_destination":   resourceDestination(),
-			"bindplane_source":        resourceSource(), // TODO(jsirianni): Determine if sources should be supported.
-			"bindplane_processor":     resourceProcessor(),
-			"bindplane_extension":     resourceExtension(),
+			"bindplane_configuration":    resourceConfiguration(),
+			"bindplane_destination":      resourceDestination(),
+			"bindplane_source":           resourceSource(),
+			"bindplane_processor":        resourceProcessor(),
+			"bindplane_processor_bundle": resourceProcessorBundle(),
+			"bindplane_extension":        resourceExtension(),
 		},
 	}
 }

--- a/provider/resource_destination.go
+++ b/provider/resource_destination.go
@@ -98,7 +98,7 @@ func resourceDestinationCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, destType, model.KindDestination, parameters)
+	r, err := resource.AnyResourceV1(name, destType, model.KindDestination, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_extension.go
+++ b/provider/resource_extension.go
@@ -98,7 +98,7 @@ func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, extensionType, model.KindExtension, parameters)
+	r, err := resource.AnyResourceV1(name, extensionType, model.KindExtension, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_processor.go
+++ b/provider/resource_processor.go
@@ -46,7 +46,7 @@ func resourceProcessor() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    false,
-				Description: "The destination type to use for processor creation.",
+				Description: "The processor type to use for processor creation.",
 			},
 			"parameters_json": {
 				Type:        schema.TypeString,
@@ -98,7 +98,7 @@ func resourceProcessorCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, parameters)
+	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_processor_bundle.go
+++ b/provider/resource_processor_bundle.go
@@ -195,11 +195,7 @@ func resourceProcessorBundleRead(d *schema.ResourceData, meta any) error {
 		processor["name"] = strings.Split(p.Name, ":")[0]
 		processorBlocks = append(processorBlocks, processor)
 	}
-	if err := d.Set("processor", processorBlocks); err != nil {
-		return err
-	}
-
-	return nil
+	return d.Set("processor", processorBlocks)
 }
 
 func resourceProcessorBundleDelete(d *schema.ResourceData, meta any) error {

--- a/provider/resource_processor_bundle.go
+++ b/provider/resource_processor_bundle.go
@@ -1,0 +1,211 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/observiq/bindplane-op-enterprise/model"
+	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/resource"
+)
+
+func resourceProcessorBundle() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceProcessorBundleCreate,
+		Update: resourceProcessorBundleCreate,
+		Read:   resourceProcessorBundleRead,
+		Delete: resourceProcessorBundleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceProcessorBundleImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the processor bundle.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				ForceNew:    false,
+				Description: "The type of the processor bundle.",
+			},
+			"parameters_json": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				ForceNew:    false,
+				Description: "Not implemented.",
+			},
+			"processor": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The processors to use for the processor bundle.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The name of the processor.",
+						},
+					},
+				},
+			},
+			"rollout": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    false,
+				Description: "Whether or not to trigger a rollout automatically when a configuration is updated. When set to true, BindPlane OP will automatically roll out the configuration change to managed agents.",
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(maxTimeout),
+			Read:   schema.DefaultTimeout(maxTimeout),
+			Delete: schema.DefaultTimeout(maxTimeout),
+		},
+	}
+}
+
+func resourceProcessorBundleCreate(d *schema.ResourceData, meta any) error {
+
+	bindplane := meta.(*client.BindPlane)
+
+	processorType := d.Get("type").(string)
+	if processorType == "" {
+		// TODO(jsirianni): Move to default const
+		processorType = "processor_bundle"
+	}
+
+	name := d.Get("name").(string)
+	rollout := d.Get("rollout").(bool)
+
+	// If id is unset, it means Terraform has not previously created
+	// this resource. Check to ensure a resource with this name does
+	// not already exist.
+	if d.Id() == "" {
+		c, err := bindplane.Processor(name)
+		if err != nil {
+			return err
+		}
+		if c != nil {
+			return fmt.Errorf("processor with name '%s' already exists with id '%s'", name, c.ID())
+		}
+	}
+
+	// Using resource configuration instead of []string (names)
+	// to allow for future use of type + parameters_json.
+	processors := []model.ResourceConfiguration{}
+	if d.Get("processor") != nil {
+		processorsRaw := d.Get("processor").([]any)
+		for _, v := range processorsRaw {
+			processorRaw := v.(map[string]any)
+
+			processor := model.ResourceConfiguration{}
+			if processorRaw["name"] != nil {
+				processor.Name = processorRaw["name"].(string)
+
+				// If name was set, return early to avoid
+				// setting type and parameters
+				processors = append(processors, processor)
+				continue
+			}
+
+			processors = append(processors, processor)
+		}
+	}
+
+	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, nil, processors)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	timeout := d.Timeout(schema.TimeoutCreate) - time.Minute
+	if err := bindplane.ApplyWithRetry(ctx, timeout, &r, rollout); err != nil {
+		return err
+	}
+
+	return resourceProcessorBundleRead(d, meta)
+}
+
+func resourceProcessorBundleRead(d *schema.ResourceData, meta any) error {
+	bindplane := meta.(*client.BindPlane)
+	resourceName := d.Get("name").(string)
+
+	g, err := bindplane.GenericResource(model.KindProcessor, resourceName)
+	if err != nil {
+		return err
+	}
+
+	// A nil return from GenericResource indicates that the resource
+	// did not exist. Terraform read operations should always set the
+	// ID to "" and return a nil error. This will allow Terraform to
+	// re-create the resource or comfirm that it was deleted.
+	if g == nil {
+		d.SetId("")
+		return nil
+	}
+
+	// Save values returned by bindplane to Terraform's state
+
+	d.SetId(g.ID)
+
+	// If the state ID is set but differs from the ID returned by,
+	// bindplane, mark the resource to be re-created by unsetting
+	// the ID. This will cause Terraform to attempt to create the resource
+	// instead of updating it. The creation step will fail because
+	// the resource already exists. This behavior is desirable, it will
+	// prevent Terraform from modifying resources created by other means.
+	if id := d.Id(); id != "" {
+		if g.ID != d.Id() {
+			d.SetId("")
+			return nil
+		}
+	}
+
+	if err := d.Set("name", g.Name); err != nil {
+		return err
+	}
+
+	rType := strings.Split(g.Spec.Type, ":")[0]
+	if err := d.Set("type", rType); err != nil {
+		return err
+	}
+
+	processorBlocks := []map[string]any{}
+	for _, p := range g.Spec.Processors {
+		processor := map[string]any{}
+		processor["name"] = strings.Split(p.Name, ":")[0]
+		processorBlocks = append(processorBlocks, processor)
+	}
+	if err := d.Set("processor", processorBlocks); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceProcessorBundleDelete(d *schema.ResourceData, meta any) error {
+	return genericResourceDelete(model.KindProcessor, d, meta)
+}
+
+func resourceProcessorBundleImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	return genericResourceImport(model.KindProcessor, d, meta)
+}

--- a/provider/resource_source.go
+++ b/provider/resource_source.go
@@ -99,7 +99,7 @@ func resourceSourceCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, sourceType, model.KindSource, parameters)
+	r, err := resource.AnyResourceV1(name, sourceType, model.KindSource, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -254,3 +254,125 @@ resource "bindplane_processor_bundle" "bundle" {
     name = bindplane_processor.batch.name
   }
 }
+
+resource "bindplane_source" "splunk_tcp" {
+  rollout = false
+  name    = "Splunk"
+  type    = "splunk_tcp"
+}
+
+resource "bindplane_processor" "json_parser" {
+  rollout = false
+  name    = "Parse-JSON-Body"
+  type    = "parse_json"
+}
+
+resource "bindplane_processor" "severity_parser_v2" {
+  rollout = false
+  name = "Parse-Severity-HTTP-Status-v2"
+  type = "parse_severity_v2"
+  parameters_json = jsonencode(
+  [
+    {
+      "name": "match",
+      "value": "Body"
+    },
+    {
+      "name": "body_severity_field",
+      "value": "level"
+    },
+  ]
+  )
+}
+
+resource "bindplane_processor" "time_parser" {
+  rollout = false
+  name    = "Parse-Timestamp"
+  type    = "parse_timestamp"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": [
+          "Logs"
+        ]
+      },
+      {
+        "name": "log_field_type",
+        "value": "Body"
+      },
+      {
+        "name": "log_source_field",
+        "value": "datetime"
+      },
+      {
+        "name": "log_time_format",
+        "value": "Manual"
+      },
+      {
+        "name": "log_manual_timestamp_layout",
+        "value": "%d/%b/%Y:%H:%M:%S %z"
+      },
+    ]
+  )
+}
+
+resource "bindplane_processor" "cleanup_promoted" {
+  rollout = false
+  name    = "k8s-trace-cleanup"
+  type    = "delete_fields_v2"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": ["Logs"]
+      },
+      {
+        "name": "resource_attributes",
+        "value": ["level","datetime"]
+      },
+    ]
+  )
+}
+
+resource "bindplane_processor_bundle" "parser" {
+  rollout = true
+  name = "generic-parse-bundle"
+
+  processor {
+    name = bindplane_processor.json_parser.name
+  }
+
+  processor {
+    name = bindplane_processor.severity_parser_v2.name
+  }
+
+  processor {
+    name = bindplane_processor.time_parser.name
+  }
+
+  processor {
+    name = bindplane_processor.cleanup_promoted.name
+  }
+}
+
+resource "bindplane_configuration" "splunk" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  rollout  = true
+  name     = "splunk"
+  platform = "linux"
+
+  source {
+    name = bindplane_source.splunk_tcp.name
+    processors = [
+      bindplane_processor_bundle.parser.name,
+    ]
+  }
+
+  destination {
+    name = bindplane_destination.logging.name
+  }
+}

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -66,6 +66,10 @@ resource "bindplane_configuration" "config" {
 
   destination {
     name = bindplane_destination.logging2.name
+    processors = [
+      bindplane_processor_bundle.bundle.name,
+      bindplane_processor.batch.name
+    ]
   }
 
   source {
@@ -236,4 +240,17 @@ resource "bindplane_extension" "custom" {
       }
     ]
   )
+}
+
+resource "bindplane_processor_bundle" "bundle" {
+  rollout = true
+  name = "my-bundle"
+
+  processor {
+    name = bindplane_processor.batch-options.name
+  }
+
+  processor {
+    name = bindplane_processor.batch.name
+  }
 }

--- a/test/local/bundle.tf
+++ b/test/local/bundle.tf
@@ -1,0 +1,166 @@
+resource "bindplane_destination" "logging" {
+  rollout = true
+  name = "logging"
+  type = "custom"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": ["Metrics", "Logs", "Traces"]
+      },
+      {
+        "name": "configuration",
+        "value": "logging:"
+      }
+    ]
+  )
+}
+
+resource "bindplane_source" "splunk_tcp" {
+  rollout = false
+  name    = "Splunk"
+  type    = "splunk_tcp"
+}
+
+resource "bindplane_source" "fluent" {
+  rollout = false
+  name    = "Fluent"
+  type    = "fluentforward"
+}
+
+resource "bindplane_processor" "json_parser" {
+  rollout = false
+  name    = "Parse-JSON-Body"
+  type    = "parse_json"
+}
+
+resource "bindplane_processor" "severity_parser_v2" {
+  rollout = false
+  name = "Parse-Severity-HTTP-Status-v2"
+  type = "parse_severity_v2"
+  parameters_json = jsonencode(
+  [
+    {
+      "name": "match",
+      "value": "Body"
+    },
+    {
+      "name": "body_severity_field",
+      "value": "level"
+    },
+  ]
+  )
+}
+
+resource "bindplane_processor" "time_parser" {
+  rollout = false
+  name    = "Parse-Timestamp"
+  type    = "parse_timestamp"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": [
+          "Logs"
+        ]
+      },
+      {
+        "name": "log_field_type",
+        "value": "Body"
+      },
+      {
+        "name": "log_source_field",
+        "value": "datetime"
+      },
+      {
+        "name": "log_time_format",
+        "value": "Manual"
+      },
+      {
+        "name": "log_manual_timestamp_layout",
+        "value": "%d/%b/%Y:%H:%M:%S %z"
+      },
+    ]
+  )
+}
+
+resource "bindplane_processor" "cleanup_promoted" {
+  rollout = false
+  name    = "cleanup"
+  type    = "delete_fields_v2"
+  parameters_json = jsonencode(
+    [
+      {
+        "name": "telemetry_types",
+        "value": ["Logs"]
+      },
+      {
+        "name": "resource_attributes",
+        "value": ["level","datetime"]
+      },
+    ]
+  )
+}
+
+resource "bindplane_processor_bundle" "parser" {
+  rollout = true
+  name = "generic-parse-bundle"
+
+  processor {
+    name = bindplane_processor.json_parser.name
+  }
+
+  processor {
+    name = bindplane_processor.severity_parser_v2.name
+  }
+
+  processor {
+    name = bindplane_processor.time_parser.name
+  }
+
+  processor {
+    name = bindplane_processor.cleanup_promoted.name
+  }
+}
+
+resource "bindplane_configuration" "splunk" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  rollout  = true
+  name     = "splunk"
+  platform = "linux"
+
+  source {
+    name = bindplane_source.splunk_tcp.name
+    processors = [
+      bindplane_processor_bundle.parser.name,
+    ]
+  }
+
+  destination {
+    name = bindplane_destination.logging.name
+  }
+}
+
+resource "bindplane_configuration" "fluent" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  rollout  = true
+  name     = "fluent"
+  platform = "linux"
+
+  source {
+    name = bindplane_source.fluent.name
+    processors = [
+      bindplane_processor_bundle.parser.name,
+    ]
+  }
+
+  destination {
+    name = bindplane_destination.logging.name
+  }
+}

--- a/test/local/main.tf
+++ b/test/local/main.tf
@@ -104,6 +104,9 @@ resource "bindplane_configuration" "configuration" {
 
   source {
     name = bindplane_source.journald.name
+    processors = [
+      bindplane_processor_bundle.bundle.name,
+    ]
   }
 
   source {
@@ -206,4 +209,17 @@ resource "bindplane_extension" "pprof" {
       },
     ]
   )
+}
+
+resource "bindplane_processor_bundle" "bundle" {
+  rollout = true
+  name = "my-bundle"
+
+  processor {
+    name = bindplane_processor.batch.name
+  }
+
+  processor {
+    name = bindplane_processor.time-parse-http-datatime.name
+  }
 }


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

[Processor bundles](https://bindplane.com/docs/feature-guides/processor-bundles) were introduced in Bindplane v1.85.0. They allow you to group a set of processors into a single processor. 

For example, you might have a raw log that should be parsed as json. From there, you might parse the timestamp and severity. Lastly, you can cleanup the parsed fields as they are no longer required.

```json
{
  "host": "31.68.180.87",
  "user-identifier": "beier6141",
  "datetime": "06/Feb/2025:15:00:50 +0000",
  "method": "DELETE",
  "request": "/generate/enterprise/intuitive",
  "protocol": "HTTP/1.1",
  "level": "info",
  "status": 200,
  "bytes": 19526,
}
```

This example shows how to create four processors, attach them to a bundle, and then attach them to multiple configurations. The sources and destinations are omitted for brevity.

```tf
resource "bindplane_processor" "json_parser" {
  rollout = false
  name    = "Parse-JSON-Body"
  type    = "parse_json"
}

resource "bindplane_processor" "severity_parser_v2" {
  rollout = false
  name = "Parse-Severity-HTTP-Status-v2"
  type = "parse_severity_v2"
  parameters_json = jsonencode(
  [
    {
      "name": "match",
      "value": "Body"
    },
    {
      "name": "body_severity_field",
      "value": "level"
    },
  ]
  )
}

resource "bindplane_processor" "time_parser" {
  rollout = false
  name    = "Parse-Timestamp"
  type    = "parse_timestamp"
  parameters_json = jsonencode(
    [
      {
        "name": "telemetry_types",
        "value": [
          "Logs"
        ]
      },
      {
        "name": "log_field_type",
        "value": "Body"
      },
      {
        "name": "log_source_field",
        "value": "datetime"
      },
      {
        "name": "log_time_format",
        "value": "Manual"
      },
      {
        "name": "log_manual_timestamp_layout",
        "value": "%d/%b/%Y:%H:%M:%S %z"
      },
    ]
  )
}

resource "bindplane_processor" "cleanup_promoted" {
  rollout = false
  name    = "k8s-trace-cleanup"
  type    = "delete_fields_v2"
  parameters_json = jsonencode(
    [
      {
        "name": "telemetry_types",
        "value": ["Logs"]
      },
      {
        "name": "resource_attributes",
        "value": ["level","datetime"]
      },
    ]
  )
}

resource "bindplane_processor_bundle" "parser" {
  rollout = true
  name = "generic-parse-bundle"

  processor {
    name = bindplane_processor.json_parser.name
  }

  processor {
    name = bindplane_processor.severity_parser_v2.name
  }

  processor {
    name = bindplane_processor.time_parser.name
  }

  processor {
    name = bindplane_processor.cleanup_promoted.name
  }
}

resource "bindplane_configuration" "splunk" {
  lifecycle {
    create_before_destroy = true
  }

  rollout  = true
  name     = "splunk"
  platform = "linux"

  source {
    name = bindplane_source.splunk_tcp.name
    processors = [
      bindplane_processor_bundle.parser.name,
    ]
  }

  destination {
    name = bindplane_destination.logging.name
  }
}

resource "bindplane_configuration" "fluent" {
  lifecycle {
    create_before_destroy = true
  }

  rollout  = true
  name     = "fluent"
  platform = "linux"

  source {
    name = bindplane_source.fluent.name
    processors = [
      bindplane_processor_bundle.parser.name,
    ]
  }

  destination {
    name = bindplane_destination.logging.name
  }
}
```

Once applied, you can use the CLI to inspect the bundle. Processor bundles are just processors, with embedded processors.

```yaml
# bindplane get processor "generic-parse-bundle"

apiVersion: bindplane.observiq.com/v1
kind: Processor
metadata:
    id: 01JKEYK1N6VAECP4M5WXXTFE8T
    name: generic-parse-bundle
    hash: 048d379f6682e9a710e6e9f6bb13499f93f4e626ca3f70c661450578ee176033
    version: 1
    dateModified: 2025-02-06T19:57:36.690079358-05:00
spec:
    type: processor_bundle:1
    processors:
        - id: p-Parse-JSON-Body
          name: Parse-JSON-Body:1
        - id: p-Parse-Severity-HTTP-Status-v2
          name: Parse-Severity-HTTP-Status-v2:1
        - id: p-Parse-Timestamp
          name: Parse-Timestamp:1
        - id: p-k8s-trace-cleanup
          name: k8s-trace-cleanup:1
status:
    latest: true
```

When viewing one of the configurations, I can see the bundle with its four processors in the correct order.

![Screenshot From 2025-02-06 20-01-11](https://github.com/user-attachments/assets/a16c017f-9be7-47df-ad1f-4f31c7000219)

## Testing

While testing, I verified the following.

1. Changes are idempotent, you run apply multiple times without resulting in additional changes
2. If you re-order the bundle in the UI, Terraform apply will revert the change
3. If you remove the bundle from a config, Terraform will revert the change
4. Bundles can be imported
5. Terraform destroy will delete the bundle

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
