### PR TITLE
feat: Generate component IDs before applying new resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/observiq/bindplane-op-enterprise v1.86.0
+	github.com/oklog/ulid/v2 v2.1.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	go.uber.org/zap v1.27.0
@@ -135,7 +136,6 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/observiq/stanza v1.6.1 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.118.0 // indirect

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -1,0 +1,14 @@
+package component
+
+import (
+	"fmt"
+
+	"github.com/observiq/bindplane-op-enterprise/model"
+)
+
+// NewResourceID wraps model.NewResourceID and returns
+// a new resource ID with the `tf` prefix to indicate
+// that it was created by the Terraform provider.
+func NewResourceID() string {
+	return fmt.Sprintf("tf-%s", model.NewResourceID())
+}

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package component
 
 import (

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package component provides functions for defining bindplane
+// component values.
 package component
 
 import (

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -1,0 +1,16 @@
+package component
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewResourceID(t *testing.T) {
+	id := NewResourceID()
+	require.True(t, strings.HasPrefix(id, "tf-"))
+	_, err := ulid.Parse(strings.TrimPrefix(id, "tf-"))
+	require.NoError(t, err)
+}

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package component
 
 import (

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -28,7 +28,7 @@ import (
 // configurations, use AnyResourceFromConfigurationV1.
 //
 // rParameters and rProcessors can be nil.
-func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Parameter, rProcessors []model.ResourceConfiguration) (model.AnyResource, error) {
+func AnyResourceV1(id, rName, rType string, rKind model.Kind, rParameters []model.Parameter, rProcessors []model.ResourceConfiguration) (model.AnyResource, error) {
 	procs := []map[string]string{}
 	for _, p := range rProcessors {
 		proc := map[string]string{}
@@ -47,6 +47,7 @@ func AnyResourceV1(rName, rType string, rKind model.Kind, rParameters []model.Pa
 				APIVersion: "bindplane.observiq.com/v1",
 				Kind:       rKind,
 				Metadata: model.Metadata{
+					ID:   id,
 					Name: rName,
 				},
 			},

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -24,6 +24,7 @@ import (
 func TestAnyResourceV1(t *testing.T) {
 	cases := []struct {
 		name        string
+		id          string
 		rName       string
 		rType       string
 		rkind       model.Kind
@@ -33,6 +34,7 @@ func TestAnyResourceV1(t *testing.T) {
 	}{
 		{
 			"source",
+			"tf-source",
 			"my-host",
 			"host",
 			model.KindSource,
@@ -51,6 +53,7 @@ func TestAnyResourceV1(t *testing.T) {
 		},
 		{
 			"destination",
+			"tf-destination",
 			"my-destination",
 			"googlecloud",
 			model.KindDestination,
@@ -65,6 +68,7 @@ func TestAnyResourceV1(t *testing.T) {
 		},
 		{
 			"processor",
+			"tf-processor",
 			"my-filter",
 			"filter",
 			model.KindProcessor,
@@ -74,6 +78,7 @@ func TestAnyResourceV1(t *testing.T) {
 		},
 		{
 			"extension",
+			"tf-extension",
 			"my-extension",
 			"pprof",
 			model.KindExtension,
@@ -83,6 +88,7 @@ func TestAnyResourceV1(t *testing.T) {
 		},
 		{
 			"invalid-kind",
+			"tf-resource",
 			"my-resource",
 			"resource",
 			model.KindAgent,
@@ -92,6 +98,7 @@ func TestAnyResourceV1(t *testing.T) {
 		},
 		{
 			"valid-processors",
+			"tf-bundle",
 			"my-bundle",
 			"bundle",
 			model.KindProcessor,
@@ -110,7 +117,7 @@ func TestAnyResourceV1(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := AnyResourceV1("", tc.rName, tc.rType, tc.rkind, tc.rParameters, tc.rProcessors)
+			_, err := AnyResourceV1(tc.id, tc.rName, tc.rType, tc.rkind, tc.rParameters, tc.rProcessors)
 			if tc.expectErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.expectErr)

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -110,7 +110,7 @@ func TestAnyResourceV1(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := AnyResourceV1(tc.rName, tc.rType, tc.rkind, tc.rParameters, tc.rProcessors)
+			_, err := AnyResourceV1("", tc.rName, tc.rType, tc.rkind, tc.rParameters, tc.rProcessors)
 			if tc.expectErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.expectErr)

--- a/provider/resource_destination.go
+++ b/provider/resource_destination.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/observiq/bindplane-op-enterprise/model"
 	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/component"
 	"github.com/observiq/terraform-provider-bindplane/internal/parameter"
 	"github.com/observiq/terraform-provider-bindplane/internal/resource"
 )
@@ -87,7 +88,13 @@ func resourceDestinationCreate(d *schema.ResourceData, meta any) error {
 		if c != nil {
 			return fmt.Errorf("destination with name '%s' already exists with id '%s'", name, c.ID())
 		}
+
+		// If a source does not already exist with this name
+		// and an ID is not set, generate and ID.
+		d.SetId(component.NewResourceID())
 	}
+
+	id := d.Id()
 
 	parameters := []model.Parameter{}
 	if s := d.Get("parameters_json").(string); s != "" {
@@ -98,7 +105,7 @@ func resourceDestinationCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, destType, model.KindDestination, parameters, nil)
+	r, err := resource.AnyResourceV1(id, name, destType, model.KindDestination, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_extension.go
+++ b/provider/resource_extension.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/observiq/bindplane-op-enterprise/model"
 	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/component"
 	"github.com/observiq/terraform-provider-bindplane/internal/parameter"
 	"github.com/observiq/terraform-provider-bindplane/internal/resource"
 )
@@ -87,7 +88,13 @@ func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
 		if c != nil {
 			return fmt.Errorf("extension with name '%s' already exists with id '%s'", name, c.ID())
 		}
+
+		// If a source does not already exist with this name
+		// and an ID is not set, generate and ID.
+		d.SetId(component.NewResourceID())
 	}
+
+	id := d.Id()
 
 	parameters := []model.Parameter{}
 	if s := d.Get("parameters_json").(string); s != "" {
@@ -98,7 +105,7 @@ func resourceExtensionCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, extensionType, model.KindExtension, parameters, nil)
+	r, err := resource.AnyResourceV1(id, name, extensionType, model.KindExtension, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_generic.go
+++ b/provider/resource_generic.go
@@ -39,15 +39,11 @@ func genericResourceRead(rKind model.Kind, d *schema.ResourceData, meta any) err
 	// A nil return from GenericResource indicates that the resource
 	// did not exist. Terraform read operations should always set the
 	// ID to "" and return a nil error. This will allow Terraform to
-	// re-create the resource or comfirm that it was deleted.
+	// re-create the resource or confirm that it was deleted.
 	if g == nil {
 		d.SetId("")
 		return nil
 	}
-
-	// Save values returned by bindplane to Terraform's state
-
-	d.SetId(g.ID)
 
 	// If the state ID is set but differs from the ID returned by,
 	// bindplane, mark the resource to be re-created by unsetting
@@ -55,11 +51,9 @@ func genericResourceRead(rKind model.Kind, d *schema.ResourceData, meta any) err
 	// instead of updating it. The creation step will fail because
 	// the resource already exists. This behavior is desirable, it will
 	// prevent Terraform from modifying resources created by other means.
-	if id := d.Id(); id != "" {
-		if g.ID != d.Id() {
-			d.SetId("")
-			return nil
-		}
+	if g.ID != d.Id() {
+		d.SetId("")
+		return nil
 	}
 
 	if err := d.Set("name", g.Name); err != nil {

--- a/provider/resource_processor.go
+++ b/provider/resource_processor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/observiq/bindplane-op-enterprise/model"
 	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/component"
 	"github.com/observiq/terraform-provider-bindplane/internal/parameter"
 	"github.com/observiq/terraform-provider-bindplane/internal/resource"
 )
@@ -87,7 +88,13 @@ func resourceProcessorCreate(d *schema.ResourceData, meta any) error {
 		if c != nil {
 			return fmt.Errorf("processor with name '%s' already exists with id '%s'", name, c.ID())
 		}
+
+		// If a source does not already exist with this name
+		// and an ID is not set, generate and ID.
+		d.SetId(component.NewResourceID())
 	}
+
+	id := d.Id()
 
 	parameters := []model.Parameter{}
 	if s := d.Get("parameters_json").(string); s != "" {
@@ -98,7 +105,7 @@ func resourceProcessorCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, parameters, nil)
+	r, err := resource.AnyResourceV1(id, name, processorType, model.KindProcessor, parameters, nil)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_processor_bundle.go
+++ b/provider/resource_processor_bundle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/observiq/bindplane-op-enterprise/model"
 	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/component"
 	"github.com/observiq/terraform-provider-bindplane/internal/resource"
 )
 
@@ -107,7 +108,13 @@ func resourceProcessorBundleCreate(d *schema.ResourceData, meta any) error {
 		if c != nil {
 			return fmt.Errorf("processor with name '%s' already exists with id '%s'", name, c.ID())
 		}
+
+		// If a source does not already exist with this name
+		// and an ID is not set, generate and ID.
+		d.SetId(component.NewResourceID())
 	}
+
+	id := d.Id()
 
 	// Using resource configuration instead of []string (names)
 	// to allow for future use of type + parameters_json.
@@ -131,7 +138,7 @@ func resourceProcessorBundleCreate(d *schema.ResourceData, meta any) error {
 		}
 	}
 
-	r, err := resource.AnyResourceV1(name, processorType, model.KindProcessor, nil, processors)
+	r, err := resource.AnyResourceV1(id, name, processorType, model.KindProcessor, nil, processors)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_source.go
+++ b/provider/resource_source.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/observiq/bindplane-op-enterprise/model"
 	"github.com/observiq/terraform-provider-bindplane/client"
+	"github.com/observiq/terraform-provider-bindplane/internal/component"
 	"github.com/observiq/terraform-provider-bindplane/internal/parameter"
 	"github.com/observiq/terraform-provider-bindplane/internal/resource"
 )
@@ -88,7 +89,13 @@ func resourceSourceCreate(d *schema.ResourceData, meta any) error {
 		if c != nil {
 			return fmt.Errorf("source with name '%s' already exists with id '%s'", name, c.ID())
 		}
+
+		// If a source does not already exist with this name
+		// and an ID is not set, generate and ID.
+		d.SetId(component.NewResourceID())
 	}
+
+	id := d.Id()
 
 	parameters := []model.Parameter{}
 	if s := d.Get("parameters_json").(string); s != "" {
@@ -99,7 +106,7 @@ func resourceSourceCreate(d *schema.ResourceData, meta any) error {
 		parameters = params
 	}
 
-	r, err := resource.AnyResourceV1(name, sourceType, model.KindSource, parameters, nil)
+	r, err := resource.AnyResourceV1(id, name, sourceType, model.KindSource, parameters, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

This is a prerequisite PR for the configuration v2 (advanced routing) effort.

Components (Sources, processors, etc) have IDs associated with them. If they are not present in the API payload, Bindplane will generate them. 

Up until now, this is how it has worked:
1. Provider applies new resources with name only (no id)
2. Bindplane creates resource
3. Provider reads resource from API
4. Provider sets the state ID from the returned resources `metadata.Id` field

This works well, and allows the Terraform state to track the resource ID. We use the ID to determine if the resource was deleted and re-created outside of Terraform.

The motivation for this change stems from Configuration V2. Bindplane config v2 relies on the presence of component ID in order to configure routes. When working with config v2, we can no longer rely on Bindplane to generate IDs for us because the API rejects the payload the provider sends.

Example:

```yaml
sources:
    - id: 01JKK4876WD433S36NRWT0YAC8
      name: journald-v2
      routes:
        logs+metrics+traces:
            - id: "0"
              components:
                - destinations/01JKK48X3TN5YXHXP43VJP93TM
destinations:
    - id: 01JKK48X3TN5YXHXP43VJP93TM
      name: loki-v2
```

The destination's ID is used in the route. If the Id is not present, the route will be considered invalid and the API call will be rejected.

## Backwards Compatibility

This change will not clobber existing component IDs in the Terraform state. Only new resources will utilize IDs generated by the provider.

## Testing

1. Checkout main and run `make test-local` to build the provider
2. Run apply resources in `test/local/`
3. Observe that the sources have IDs generated by Bindplane (a ULID)
4. Checkout this branch and re-build with `make test-local`
5. Observe that Terraform apply does not update existing resources
6. Delete a source and re-create it in the UI
7. Observe that Terraform apply fails with an error indicating that the resource already exists
8. Run `terraform destroy`, delete manually created resources
9. Run `terraform apply`
10. Observe generated resources are in use

```yaml
apiVersion: bindplane.observiq.com/v1
kind: Source
metadata:
    id: tf-01JKK7N2VN11MJ6Z0NWBW55XJZ
    name: Fluent
    hash: f13ee06731922f3539c91a699112b853edd9a280b3f098bdea2b2ac2f1658aa4
    version: 1
    dateModified: 2025-02-08T11:52:58.358174608-05:00
spec:
    type: fluentforward:1
status:
    latest: true
```

When viewing the state for the same source, you can see the matching ID

```tf
# bindplane_source.fluent:
resource "bindplane_source" "fluent" {
    id              = "tf-01JKK7N2VN11MJ6Z0NWBW55XJZ"
    name            = "Fluent"
    parameters_json = null
    rollout         = false
    type            = "fluentforward"
}
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
