### PR TITLE
fix: Config v2 routes should use TypeSet to avoid ordering requirements

### DIFF
--- a/internal/component/route.go
+++ b/internal/component/route.go
@@ -136,90 +136,37 @@ func ParseRoutes(rawRoutes []any) (*model.Routes, error) {
 // RoutesToState takes a model.Routes object and returns a []map[string]any
 // which is suitable for writing to the state.
 //
-// Returns nil, nil if routes is nil.
-func RoutesToState(routes *model.Routes) ([]map[string]any, error) {
-	if routes == nil {
+// Returns nil, nil if routes is nil. It is up to the caller to ensure
+// the returned value is not nil before attempting to read from it.
+func RoutesToState(inRoutes *model.Routes) ([]map[string]any, error) {
+	if inRoutes == nil {
 		return nil, nil
 	}
 
 	stateRoutes := []map[string]any{}
 
-	logRoutes := routes.Logs
-	if len(logRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range logRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "logs",
-				"components":     r.Components,
-			})
-		}
-		stateRoutes = append(stateRoutes, routes...)
+	routeMap := map[string][]model.Route{
+		RouteTypeLogs:              inRoutes.Logs,
+		RouteTypeMetrics:           inRoutes.Metrics,
+		RouteTypeTraces:            inRoutes.Traces,
+		RouteTypeLogsMetrics:       inRoutes.LogsMetrics,
+		RouteTypeLogsTraces:        inRoutes.LogsTraces,
+		RouteTypeMetricsTraces:     inRoutes.MetricsTraces,
+		RouteTypeLogsMetricsTraces: inRoutes.LogsMetricsTraces,
 	}
-	metricRoutes := routes.Metrics
-	if len(metricRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range metricRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "metrics",
-				"components":     r.Components,
-			})
+
+	for routeType, routes := range routeMap {
+		if len(routes) > 0 {
+			r := []map[string]any{}
+			for _, route := range routes {
+				r = append(r, map[string]any{
+					"telemetry_type": routeType,
+					"components":     route.Components,
+				})
+			}
+			stateRoutes = append(stateRoutes, r...)
 		}
-		stateRoutes = append(stateRoutes, routes...)
 	}
-	traceRoutes := routes.Traces
-	if len(traceRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range traceRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "traces",
-				"components":     r.Components,
-			})
-		}
-		stateRoutes = append(stateRoutes, routes...)
-	}
-	logMetricRoutes := routes.LogsMetrics
-	if len(logMetricRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range logMetricRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "logs+metrics",
-				"components":     r.Components,
-			})
-		}
-		stateRoutes = append(stateRoutes, routes...)
-	}
-	logTraceRoutes := routes.LogsTraces
-	if len(logTraceRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range logTraceRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "logs+traces",
-				"components":     r.Components,
-			})
-		}
-		stateRoutes = append(stateRoutes, routes...)
-	}
-	metricTraceRoutes := routes.MetricsTraces
-	if len(metricTraceRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range metricTraceRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "metrics+traces",
-				"components":     r.Components,
-			})
-		}
-		stateRoutes = append(stateRoutes, routes...)
-	}
-	logMetricTraceRoutes := routes.LogsMetricsTraces
-	if len(logMetricTraceRoutes) > 0 {
-		routes := []map[string]any{}
-		for _, r := range logMetricTraceRoutes {
-			routes = append(routes, map[string]any{
-				"telemetry_type": "logs+metrics+traces",
-				"components":     r.Components,
-			})
-		}
-		stateRoutes = append(stateRoutes, routes...)
-	}
+
 	return stateRoutes, nil
 }

--- a/provider/resource_configuration_v2.go
+++ b/provider/resource_configuration_v2.go
@@ -97,7 +97,7 @@ func resourceConfigurationV2() *schema.Resource {
 							Description: "List of processor names to attach to the source.",
 						},
 						"route": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							ForceNew: false,
 							Elem: &schema.Resource{
@@ -150,7 +150,7 @@ func resourceConfigurationV2() *schema.Resource {
 							Description: "Name of the connector to attach.",
 						},
 						"route": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							ForceNew: false,
 							Elem: &schema.Resource{
@@ -204,7 +204,7 @@ func resourceConfigurationV2() *schema.Resource {
 							Description: "List of processor names to attach to the processor group.",
 						},
 						"route": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							ForceNew: false,
 							Elem: &schema.Resource{
@@ -404,7 +404,7 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 			}
 
 			routes := &model.Routes{}
-			if rawRoutes := sourcesRaw["route"].([]any); v != nil {
+			if rawRoutes := sourcesRaw["route"].(*schema.Set).List(); v != nil {
 				r, err := component.ParseRoutes(rawRoutes)
 				if err != nil {
 					return fmt.Errorf("parse routes: %w", err)
@@ -428,7 +428,7 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 			connectorRaw := v.(map[string]any)
 
 			routes := &model.Routes{}
-			if rawRoutes := connectorRaw["route"].([]any); v != nil {
+			if rawRoutes := connectorRaw["route"].(*schema.Set).List(); v != nil {
 				r, err := component.ParseRoutes(rawRoutes)
 				if err != nil {
 					return fmt.Errorf("parse routes: %w", err)
@@ -459,7 +459,7 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 			}
 
 			routes := &model.Routes{}
-			if rawRoutes := processorGroupRaw["route"].([]any); v != nil {
+			if rawRoutes := processorGroupRaw["route"].(*schema.Set).List(); v != nil {
 				r, err := component.ParseRoutes(rawRoutes)
 				if err != nil {
 					return fmt.Errorf("parse routes: %w", err)

--- a/provider/resource_configuration_v2.go
+++ b/provider/resource_configuration_v2.go
@@ -664,7 +664,7 @@ func resourceConfigurationV2Read(d *schema.ResourceData, meta any) error {
 		// to the new processor blocks before calling d.Set.
 		for _, stateProcessorGroup := range stateProcessorGroupBlocks {
 			stateProcessorGroup := stateProcessorGroup.(map[string]any)
-			if stateProcessorGroup["name"] == processorGroup["name"] {
+			if stateProcessorGroup["route_id"] == pg.ID {
 				processorGroup["route_id"] = stateProcessorGroup["route_id"]
 				break
 			}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

TypeList is ordered. If a user configures their routes "out of order" (e.g. metrics before logs), the provider will attempt to rectify it over and over because routes are processed in the following order: logs, metrics, traces, etc. TypeSet works great for this situation.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
