### PR TITLE
fix(configurationv2): Remove route + syntax

### DIFF
--- a/docs/resources/bindplane_configuration_v2.md
+++ b/docs/resources/bindplane_configuration_v2.md
@@ -85,17 +85,13 @@ Configuration V2 builds upon [Configuration V1](./bindplane_configuration.md) by
 | Option              | Type         | Default  | Description                  |
 | ------------------- | ------------ | -------- | ---------------------------- |
 | `route_id`          | string       | required | A unique string that identifies the route. |
-| `telemetry_type`    | enum         | `logs+metrics+traces` | The telemetry type to route. |
+| `telemetry_type`    | enum         | required | The telemetry type to route. |
 | `components`        | list(string) | required | One or more components to route the telemetry to. |
 
 Telemetry types include the following
 - `logs`
 - `metrics`
 - `traces`
-- `logs+metrics`
-- `logs+traces`
-- `metrics+traces`
-- `logs+metrics+traces` (default)
 
 The following example shows two route blocks, one for all telemetry types and one for traces only.
 

--- a/internal/component/route.go
+++ b/internal/component/route.go
@@ -31,18 +31,6 @@ const (
 	// RouteTypeTraces routes traces
 	RouteTypeTraces = "traces"
 
-	// RouteTypeLogsMetrics routes logs and metrics
-	RouteTypeLogsMetrics = "logs+metrics"
-
-	// RouteTypeLogsTraces routes logs and traces
-	RouteTypeLogsTraces = "logs+traces"
-
-	// RouteTypeMetricsTraces routes metrics and traces
-	RouteTypeMetricsTraces = "metrics+traces"
-
-	// RouteTypeLogsMetricsTraces routes logs, metrics, and traces
-	RouteTypeLogsMetricsTraces = "logs+metrics+traces"
-
 	// RoutePrefixProcessor is the prefix for processor routes
 	RoutePrefixProcessor = "processors"
 
@@ -56,7 +44,7 @@ const (
 // ValidateRouteType returns an error if the route type is invalid
 func ValidateRouteType(routeType string) error {
 	switch routeType {
-	case RouteTypeLogs, RouteTypeMetrics, RouteTypeTraces, RouteTypeLogsMetrics, RouteTypeLogsTraces, RouteTypeMetricsTraces, RouteTypeLogsMetricsTraces:
+	case RouteTypeLogs, RouteTypeMetrics, RouteTypeTraces:
 		return nil
 	}
 	return fmt.Errorf("invalid route type: %s", routeType)
@@ -117,26 +105,6 @@ func ParseRoutes(rawRoutes []any) (*model.Routes, error) {
 				ID:         id,
 				Components: components,
 			})
-		case RouteTypeLogsMetrics:
-			routes.LogsMetrics = append(routes.LogsMetrics, model.Route{
-				ID:         id,
-				Components: components,
-			})
-		case RouteTypeLogsTraces:
-			routes.LogsTraces = append(routes.LogsTraces, model.Route{
-				ID:         id,
-				Components: components,
-			})
-		case RouteTypeMetricsTraces:
-			routes.MetricsTraces = append(routes.MetricsTraces, model.Route{
-				ID:         id,
-				Components: components,
-			})
-		case RouteTypeLogsMetricsTraces:
-			routes.LogsMetricsTraces = append(routes.LogsMetricsTraces, model.Route{
-				ID:         id,
-				Components: components,
-			})
 		}
 	}
 
@@ -156,13 +124,9 @@ func RoutesToState(inRoutes *model.Routes) ([]map[string]any, error) {
 	stateRoutes := []map[string]any{}
 
 	routeMap := map[string][]model.Route{
-		RouteTypeLogs:              inRoutes.Logs,
-		RouteTypeMetrics:           inRoutes.Metrics,
-		RouteTypeTraces:            inRoutes.Traces,
-		RouteTypeLogsMetrics:       inRoutes.LogsMetrics,
-		RouteTypeLogsTraces:        inRoutes.LogsTraces,
-		RouteTypeMetricsTraces:     inRoutes.MetricsTraces,
-		RouteTypeLogsMetricsTraces: inRoutes.LogsMetricsTraces,
+		RouteTypeLogs:    inRoutes.Logs,
+		RouteTypeMetrics: inRoutes.Metrics,
+		RouteTypeTraces:  inRoutes.Traces,
 	}
 
 	for routeType, routes := range routeMap {

--- a/internal/component/route_test.go
+++ b/internal/component/route_test.go
@@ -31,10 +31,6 @@ func TestValidateRouteType(t *testing.T) {
 		{"logs", nil},
 		{"metrics", nil},
 		{"traces", nil},
-		{"logs+metrics", nil},
-		{"logs+traces", nil},
-		{"metrics+traces", nil},
-		{"logs+metrics+traces", nil},
 		{"invalid", errors.New("invalid route type: invalid")},
 	}
 
@@ -79,11 +75,11 @@ func TestParseRoutes(t *testing.T) {
 				map[string]any{
 					"route_id":       "logs-otlp",
 					"components":     []any{"destinations/otlp"},
-					"telemetry_type": "logs+metrics+traces",
+					"telemetry_type": "logs",
 				},
 			},
 			&model.Routes{
-				LogsMetricsTraces: []model.Route{
+				Logs: []model.Route{
 					{
 						ID:         "logs-otlp",
 						Components: []model.ComponentPath{"destinations/otlp"},
@@ -110,26 +106,6 @@ func TestParseRoutes(t *testing.T) {
 					"components":     []any{"destinations/jaeger"},
 					"telemetry_type": "traces",
 				},
-				map[string]any{
-					"route_id":       "logs-metrics",
-					"components":     []any{"destinations/otlp", "processors/batcher"},
-					"telemetry_type": "logs+metrics",
-				},
-				map[string]any{
-					"route_id":       "logs-traces",
-					"components":     []any{"destinations/otlp", "processors/batcher"},
-					"telemetry_type": "logs+traces",
-				},
-				map[string]any{
-					"route_id":       "metrics-traces",
-					"components":     []any{"destinations/otlp", "processors/batcher"},
-					"telemetry_type": "metrics+traces",
-				},
-				map[string]any{
-					"route_id":       "all",
-					"components":     []any{"destinations/otlp", "processors/batcher", "connectors/router"},
-					"telemetry_type": "logs+metrics+traces",
-				},
 			},
 			&model.Routes{
 				Logs: []model.Route{
@@ -150,30 +126,6 @@ func TestParseRoutes(t *testing.T) {
 						Components: []model.ComponentPath{"destinations/jaeger"},
 					},
 				},
-				LogsMetrics: []model.Route{
-					{
-						ID:         "logs-metrics",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-					},
-				},
-				LogsTraces: []model.Route{
-					{
-						ID:         "logs-traces",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-					},
-				},
-				MetricsTraces: []model.Route{
-					{
-						ID:         "metrics-traces",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-					},
-				},
-				LogsMetricsTraces: []model.Route{
-					{
-						ID:         "all",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher", "connectors/router"},
-					},
-				},
 			},
 			false,
 		},
@@ -182,7 +134,7 @@ func TestParseRoutes(t *testing.T) {
 			[]any{
 				map[string]any{
 					"components":     []any{"dest/otlp"},
-					"telemetry_type": "logs+metrics+traces",
+					"telemetry_type": "traces",
 				},
 			},
 			nil,
@@ -269,78 +221,6 @@ func TestRoutesToState(t *testing.T) {
 					"route_id":       "jaeger",
 					"telemetry_type": "traces",
 					"components":     []model.ComponentPath{"destinations/jaeger"},
-				},
-			},
-		},
-		{
-			"logs+metrics route",
-			&model.Routes{
-				LogsMetrics: []model.Route{
-					{
-						ID:         "all-types",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-					},
-				},
-			},
-			[]map[string]any{
-				{
-					"route_id":       "all-types",
-					"telemetry_type": "logs+metrics",
-					"components":     []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-				},
-			},
-		},
-		{
-			"logs+traces route",
-			&model.Routes{
-				LogsTraces: []model.Route{
-					{
-						ID:         "logs-traces",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-					},
-				},
-			},
-			[]map[string]any{
-				{
-					"route_id":       "logs-traces",
-					"telemetry_type": "logs+traces",
-					"components":     []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-				},
-			},
-		},
-		{
-			"metrics+traces route",
-			&model.Routes{
-				MetricsTraces: []model.Route{
-					{
-						ID:         "metrics-traces",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-					},
-				},
-			},
-			[]map[string]any{
-				{
-					"route_id":       "metrics-traces",
-					"telemetry_type": "metrics+traces",
-					"components":     []model.ComponentPath{"destinations/otlp", "processors/batcher"},
-				},
-			},
-		},
-		{
-			"logs+metrics+traces route",
-			&model.Routes{
-				LogsMetricsTraces: []model.Route{
-					{
-						ID:         "all",
-						Components: []model.ComponentPath{"destinations/otlp", "processors/batcher", "connectors/router"},
-					},
-				},
-			},
-			[]map[string]any{
-				{
-					"route_id":       "all",
-					"telemetry_type": "logs+metrics+traces",
-					"components":     []model.ComponentPath{"destinations/otlp", "processors/batcher", "connectors/router"},
 				},
 			},
 		},

--- a/provider/resource/configuration/v2/configuration.go
+++ b/provider/resource/configuration/v2/configuration.go
@@ -35,9 +35,9 @@ var RouteSchema *schema.Schema = &schema.Schema{
 			},
 			"telemetry_type": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				ForceNew:    false,
-				Description: "The telemetry type to route. Valid route types include 'logs', 'metrics', or 'traces' 'logs+metrics', 'logs+traces', 'metrics+traces', 'logs+metrics+traces'.",
+				Description: "The telemetry type to route. Valid route types include 'logs', 'metrics', or 'traces'.",
 				ValidateFunc: func(val any, _ string) (warns []string, errs []error) {
 					telemetryType := val.(string)
 					if err := component.ValidateRouteType(telemetryType); err != nil {
@@ -45,7 +45,6 @@ var RouteSchema *schema.Schema = &schema.Schema{
 					}
 					return
 				},
-				Default: component.RouteTypeLogsMetricsTraces,
 			},
 			"components": {
 				Type:        schema.TypeList,


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Bindplane API breaks logs+metrics+traces (or any other + syntax) into individual routes. This causes a Terraform apply loop as Terraform believes the configuration has changed.

We can explore supporting this syntax in the future. For now, we should be explicit and define multiple routes, one for each telemetry type.

The provider's `configuration_v2` resource has been updated to require each `route` block to include the `telemetry_type`. Previously it was optional, defaulting to `logs+metrics+traces`.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
