### PR TITLE
fix: validate condition parameters in terraform

### DIFF
--- a/internal/parameter/condition.go
+++ b/internal/parameter/condition.go
@@ -53,9 +53,10 @@ type OTTLConditionStatement struct {
 
 // ValidateOTTLConditionStatement validates that a condition UI block is properly formed and rejects malformed conditions
 func ValidateOTTLConditionStatement(ui OTTLConditionStatement) error {
-	if ui.Operator == "or" || ui.Operator == "and" {
-		if len(ui.Statements) < 2 {
-			return fmt.Errorf("parent operator '%s' must have at least 2 child statements, found %d", ui.Operator, len(ui.Statements))
+	// If operator is "and" or "or" and there are child statements, validate the child statements
+	if (ui.Operator == "or" || ui.Operator == "and") && len(ui.Statements) > 0 {
+		if len(ui.Statements) == 1 {
+			return fmt.Errorf("parent operator '%s' must not have only one child statement, found %d", ui.Operator, len(ui.Statements))
 		}
 		// Validate each child statement
 		for i, statement := range ui.Statements {
@@ -63,8 +64,8 @@ func ValidateOTTLConditionStatement(ui OTTLConditionStatement) error {
 				return fmt.Errorf("child statement %d: %w", i, err)
 			}
 		}
-		// If operator exists, it must have a key and match
 	} else if ui.Operator != "" {
+		// For statements with operators that don't have child statements, require key and match
 		if ui.Key == "" {
 			return fmt.Errorf("statement with operator '%s' must have a key", ui.Operator)
 		}

--- a/internal/parameter/condition.go
+++ b/internal/parameter/condition.go
@@ -53,7 +53,7 @@ type OTTLConditionStatement struct {
 
 // ValidateOTTLConditionStatement validates that a condition UI block is properly formed and rejects malformed conditions
 func ValidateOTTLConditionStatement(ui OTTLConditionStatement) error {
-	if ui.Operator == "OR" || ui.Operator == "AND" {
+	if ui.Operator == "or" || ui.Operator == "and" {
 		if len(ui.Statements) < 2 {
 			return fmt.Errorf("parent operator '%s' must have at least 2 child statements, found %d", ui.Operator, len(ui.Statements))
 		}

--- a/internal/parameter/condition.go
+++ b/internal/parameter/condition.go
@@ -1,0 +1,77 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameter
+
+import (
+	"fmt"
+)
+
+// Condition is the json-encoded value of the Condition parameter.
+type Condition struct {
+	// OTTL is the OTTL condition string either specified raw or generated from the UI.
+	OTTL string `mapstructure:"ottl"`
+
+	// OTTLContext is the OTTL context for the condition statement.
+	OTTLContext string `mapstructure:"ottlContext"`
+
+	// UI is the UI representation of the condition and is used to repopulate the condition
+	// UI.
+	UI OTTLConditionStatement `mapstructure:"ui"`
+}
+
+// OTTLConditionStatement represents either a single OTTL statement or a group of
+// statements joined with a boolean operator.
+type OTTLConditionStatement struct {
+	// Operator is the operator in this statement. If there are multiple statements and the
+	// operator is empty, it is assumed to be "and".
+	Operator string `mapstructure:"operator"`
+
+	// Match is the type of the field in this statement
+	Match string `mapstructure:"match"`
+
+	// Key is the key of the field in this statement
+	Key string `mapstructure:"key"`
+
+	// Value is the value to compare against using the operator in this statement
+	Value string `mapstructure:"value"`
+
+	// Statements contains sub-statements if the Operator is "and" or "or".
+	Statements []OTTLConditionStatement `mapstructure:"statements"`
+}
+
+// ValidateOTTLConditionStatement validates that a condition UI block is properly formed and rejects malformed conditions
+func ValidateOTTLConditionStatement(ui OTTLConditionStatement) error {
+	if ui.Operator == "OR" || ui.Operator == "AND" {
+		if len(ui.Statements) < 2 {
+			return fmt.Errorf("parent operator '%s' must have at least 2 child statements, found %d", ui.Operator, len(ui.Statements))
+		}
+		// Validate each child statement
+		for i, statement := range ui.Statements {
+			if err := ValidateOTTLConditionStatement(statement); err != nil {
+				return fmt.Errorf("child statement %d: %w", i, err)
+			}
+		}
+		// If operator exists, it must have a key and match
+	} else if ui.Operator != "" {
+		if ui.Key == "" {
+			return fmt.Errorf("statement with operator '%s' must have a key", ui.Operator)
+		}
+		if ui.Match == "" {
+			return fmt.Errorf("statement with operator '%s' must have a match", ui.Operator)
+		}
+	}
+
+	return nil
+}

--- a/internal/parameter/condition_test.go
+++ b/internal/parameter/condition_test.go
@@ -36,7 +36,7 @@ func TestValidateConditionStatement(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid OR with two statements",
+			name: "valid or with two statements",
 			ui: OTTLConditionStatement{
 				Operator: "or",
 				Statements: []OTTLConditionStatement{
@@ -70,7 +70,7 @@ func TestValidateConditionStatement(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "parent operator 'or' must have at least 2 child statements, found 1",
+			errMsg:  "parent operator 'or' must not have only one child statement, found 1",
 		},
 		{
 			name: "nested malformed or - should fail",
@@ -87,7 +87,7 @@ func TestValidateConditionStatement(t *testing.T) {
 						Operator: "or",
 						Statements: []OTTLConditionStatement{
 							{
-								Operator: "Equals",
+								Operator: "and",
 								Key:      "telemetry.type",
 								Match:    "resource",
 								Value:    "metric",
@@ -97,27 +97,53 @@ func TestValidateConditionStatement(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "child statement 1: parent operator 'or' must have at least 2 child statements, found 1",
+			errMsg:  "child statement 1: parent operator 'or' must not have only one child statement, found 1",
 		},
 		{
 			name: "statement with operator but no key - should fail",
 			ui: OTTLConditionStatement{
-				Operator: "Equals",
+				Operator: "or",
 				Match:    "resource",
 				Value:    "prod",
 			},
 			wantErr: true,
-			errMsg:  "statement with operator 'Equals' must have a key",
+			errMsg:  "statement with operator 'or' must have a key",
 		},
 		{
 			name: "statement with operator but no match - should fail",
 			ui: OTTLConditionStatement{
-				Operator: "Equals",
+				Operator: "and",
 				Key:      "env",
 				Value:    "prod",
 			},
 			wantErr: true,
-			errMsg:  "statement with operator 'Equals' must have a match",
+			errMsg:  "statement with operator 'and' must have a match",
+		},
+		{
+			name: "nested statement with operator but no match or - should fail",
+			ui: OTTLConditionStatement{
+				Operator: "or",
+				Statements: []OTTLConditionStatement{
+					{
+						Operator: "Equals",
+						Key:      "service",
+						Match:    "resource",
+						Value:    "example.link",
+					},
+					{
+						Operator: "or",
+						Statements: []OTTLConditionStatement{
+							{
+								Operator: "and",
+								Key:      "telemetry.type",
+								Value:    "metric",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "child statement 1: parent operator 'or' must not have only one child statement, found 1",
 		},
 
 		{

--- a/internal/parameter/condition_test.go
+++ b/internal/parameter/condition_test.go
@@ -38,7 +38,7 @@ func TestValidateConditionStatement(t *testing.T) {
 		{
 			name: "valid OR with two statements",
 			ui: OTTLConditionStatement{
-				Operator: "OR",
+				Operator: "or",
 				Statements: []OTTLConditionStatement{
 					{
 						Operator: "or",
@@ -57,9 +57,9 @@ func TestValidateConditionStatement(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "malformed OR with only one statement - should fail",
+			name: "malformed or with only one statement - should fail",
 			ui: OTTLConditionStatement{
-				Operator: "OR",
+				Operator: "or",
 				Statements: []OTTLConditionStatement{
 					{
 						Operator: "or",
@@ -70,12 +70,12 @@ func TestValidateConditionStatement(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "parent operator 'OR' must have at least 2 child statements, found 1",
+			errMsg:  "parent operator 'or' must have at least 2 child statements, found 1",
 		},
 		{
-			name: "nested malformed OR - should fail",
+			name: "nested malformed or - should fail",
 			ui: OTTLConditionStatement{
-				Operator: "OR",
+				Operator: "or",
 				Statements: []OTTLConditionStatement{
 					{
 						Operator: "Equals",
@@ -84,7 +84,7 @@ func TestValidateConditionStatement(t *testing.T) {
 						Value:    "example.link",
 					},
 					{
-						Operator: "OR",
+						Operator: "or",
 						Statements: []OTTLConditionStatement{
 							{
 								Operator: "Equals",
@@ -97,7 +97,7 @@ func TestValidateConditionStatement(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "child statement 1: parent operator 'OR' must have at least 2 child statements, found 1",
+			errMsg:  "child statement 1: parent operator 'or' must have at least 2 child statements, found 1",
 		},
 		{
 			name: "statement with operator but no key - should fail",

--- a/internal/parameter/condition_test.go
+++ b/internal/parameter/condition_test.go
@@ -1,0 +1,148 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameter
+
+import (
+	"testing"
+)
+
+func TestValidateConditionStatement(t *testing.T) {
+	tests := []struct {
+		name    string
+		ui      OTTLConditionStatement
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid single statement",
+			ui: OTTLConditionStatement{
+				Operator: "and",
+				Match:    "body",
+				Key:      "severity",
+				Value:    "ERROR",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid OR with two statements",
+			ui: OTTLConditionStatement{
+				Operator: "OR",
+				Statements: []OTTLConditionStatement{
+					{
+						Operator: "or",
+						Match:    "body",
+						Key:      "severity",
+						Value:    "ERROR",
+					},
+					{
+						Operator: "or",
+						Match:    "body",
+						Key:      "severity",
+						Value:    "INFO",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "malformed OR with only one statement - should fail",
+			ui: OTTLConditionStatement{
+				Operator: "OR",
+				Statements: []OTTLConditionStatement{
+					{
+						Operator: "or",
+						Match:    "body",
+						Key:      "severity",
+						Value:    "ERROR",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "parent operator 'OR' must have at least 2 child statements, found 1",
+		},
+		{
+			name: "nested malformed OR - should fail",
+			ui: OTTLConditionStatement{
+				Operator: "OR",
+				Statements: []OTTLConditionStatement{
+					{
+						Operator: "Equals",
+						Key:      "service",
+						Match:    "resource",
+						Value:    "example.link",
+					},
+					{
+						Operator: "OR",
+						Statements: []OTTLConditionStatement{
+							{
+								Operator: "Equals",
+								Key:      "telemetry.type",
+								Match:    "resource",
+								Value:    "metric",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "child statement 1: parent operator 'OR' must have at least 2 child statements, found 1",
+		},
+		{
+			name: "statement with operator but no key - should fail",
+			ui: OTTLConditionStatement{
+				Operator: "Equals",
+				Match:    "resource",
+				Value:    "prod",
+			},
+			wantErr: true,
+			errMsg:  "statement with operator 'Equals' must have a key",
+		},
+		{
+			name: "statement with operator but no match - should fail",
+			ui: OTTLConditionStatement{
+				Operator: "Equals",
+				Key:      "env",
+				Value:    "prod",
+			},
+			wantErr: true,
+			errMsg:  "statement with operator 'Equals' must have a match",
+		},
+
+		{
+			name:    "completely empty - should pass",
+			ui:      OTTLConditionStatement{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOTTLConditionStatement(tt.ui)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidateOTTLConditionStatement() expected error but got none")
+					return
+				}
+				if tt.errMsg != "" && err.Error() != tt.errMsg {
+					t.Errorf("ValidateOTTLConditionStatement() error = %v, want error message %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateOTTLConditionStatement() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/parameter/parameter_test.go
+++ b/internal/parameter/parameter_test.go
@@ -313,7 +313,7 @@ func TestStringToParameter_WithConditions(t *testing.T) {
 					}
 				}
 			]`,
-			"parameter validation failed: parameter 2: invalid condition UI: parent operator 'OR' must have at least 2 child statements, found 1",
+			"parameter validation failed: parameter 2: invalid condition UI: parent operator 'or' must not have only one child statement, found 1",
 		},
 		{
 			"valid-condition",

--- a/internal/parameter/parameter_test.go
+++ b/internal/parameter/parameter_test.go
@@ -272,3 +272,97 @@ func TestParametersToSring(t *testing.T) {
 		})
 	}
 }
+
+func TestStringToParameter_WithConditions(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		errMsg string
+	}{
+		{
+			"malformed-condition",
+			`[
+				{
+					"name": "telemetry_types",
+					"value": ["Logs"]
+				},
+				{
+					"name": "action",
+					"value": "exclude"
+				},
+				{
+					"name": "condition",
+					"value": {
+						"ottl": "(resource.attributes[\"service\"] == \"example.link\") or (resource.attributes[\"telemetry.type\"] == \"metric\") or (resource.attributes[\"telemetry.type\"] == \"trace\")",
+						"ui": {
+							"operator": "OR",
+							"statements": [
+								{
+									"operator": "or",
+									"statements": [
+										{
+											"key": "service",
+											"match": "resource",
+											"operator": "Equals",
+											"value": "example.link"
+										}
+									]
+								}
+							]
+						}
+					}
+				}
+			]`,
+			"parameter validation failed: parameter 2: invalid condition UI: parent operator 'OR' must have at least 2 child statements, found 1",
+		},
+		{
+			"valid-condition",
+			`[
+				{
+					"name": "telemetry_types",
+					"value": ["Logs"]
+				},
+				{
+					"name": "action",
+					"value": "exclude"
+				},
+				{
+					"name": "condition",
+					"value": {
+						"ottl": "(resource.attributes[\"service\"] == \"example.link\") or (resource.attributes[\"telemetry.type\"] == \"metric\")",
+						"ui": {
+							"operator": "OR",
+							"statements": [
+								{
+									"operator": "Equals",
+									"key": "service",
+									"match": "resource",
+									"value": "example.link"
+								},
+								{
+									"operator": "Equals",
+									"key": "telemetry.type",
+									"match": "resource",
+									"value": "metric"
+								}
+							]
+						}
+					}
+				}
+			]`,
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := StringToParameter(tc.input)
+			if tc.errMsg != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.errMsg)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/parameter/parameter_test.go
+++ b/internal/parameter/parameter_test.go
@@ -295,7 +295,7 @@ func TestStringToParameter_WithConditions(t *testing.T) {
 					"value": {
 						"ottl": "(resource.attributes[\"service\"] == \"example.link\") or (resource.attributes[\"telemetry.type\"] == \"metric\") or (resource.attributes[\"telemetry.type\"] == \"trace\")",
 						"ui": {
-							"operator": "OR",
+							"operator": "or",
 							"statements": [
 								{
 									"operator": "or",
@@ -331,7 +331,7 @@ func TestStringToParameter_WithConditions(t *testing.T) {
 					"value": {
 						"ottl": "(resource.attributes[\"service\"] == \"example.link\") or (resource.attributes[\"telemetry.type\"] == \"metric\")",
 						"ui": {
-							"operator": "OR",
+							"operator": "or",
 							"statements": [
 								{
 									"operator": "Equals",

--- a/provider/resource_processor.go
+++ b/provider/resource_processor.go
@@ -133,7 +133,7 @@ func resourceProcessorImportState(_ context.Context, d *schema.ResourceData, met
 }
 
 // validateParametersJSON validates the parameters_json field during plan phase
-func validateParametersJSON(v interface{}, k string) (ws []string, errors []error) {
+func validateParametersJSON(v any, _ string) (ws []string, errors []error) {
 	value, ok := v.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected string, got %T", v))

--- a/provider/resource_processor.go
+++ b/provider/resource_processor.go
@@ -50,10 +50,11 @@ func resourceProcessor() *schema.Resource {
 				Description: "The processor type to use for processor creation.",
 			},
 			"parameters_json": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    false,
-				Description: "A JSON object with options used to configure the processor.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				Description:  "A JSON object with options used to configure the processor.",
+				ValidateFunc: validateParametersJSON,
 			},
 			"rollout": {
 				Type:        schema.TypeBool,
@@ -129,4 +130,24 @@ func resourceProcessorDelete(d *schema.ResourceData, meta any) error {
 
 func resourceProcessorImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	return genericResourceImport(model.KindProcessor, d, meta)
+}
+
+// validateParametersJSON validates the parameters_json field during plan phase
+func validateParametersJSON(v interface{}, k string) (ws []string, errors []error) {
+	value, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected string, got %T", v))
+		return
+	}
+
+	if value == "" {
+		return
+	}
+
+	_, err := parameter.StringToParameter(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("invalid parameters_json: %w", err))
+	}
+
+	return
 }


### PR DESCRIPTION
## Description of Changes
- Prevents users from creating processors with malformed condition parameters.
   - Related thread: https://observiq.slack.com/archives/C019UAANDLZ/p1747151265464879?thread_ts=1747140058.657989&cid=C019UAANDLZ
- Adds validation function for future implementation of parameter validation.
- This parameter validation happens in the plan phase.

## Testing
- condition_test.go
- parameter_test.go
- creating a test tf file with malformed parameters, doing the init, plan, and apply. (fails on plan)

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
