### PR TITLE
feat: Use stable bindplane.observiq.com/v2 API

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -180,6 +180,17 @@ func NewV1(options ...Option) (*model.Configuration, error) {
 	return c, nil
 }
 
+// NewV2 wraps NewV2Beta and returns a BindPlane configuration
+// with API version bindplane.observiq.com/v2.
+func NewV2(options ...Option) (*model.Configuration, error) {
+	c, err := NewV2Beta(options...)
+	if err != nil {
+		return nil, err
+	}
+	c.ResourceMeta.APIVersion = "bindplane.observiq.com/v2"
+	return c, nil
+}
+
 // NewV2Beta takes a configuration options and returns a BindPlane configuration
 // with API version bindplane.observiq.com/v2beta
 func NewV2Beta(options ...Option) (*model.Configuration, error) {

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -288,3 +288,42 @@ func TestNewV2Beta(t *testing.T) {
 		})
 	}
 }
+
+func TestNewV2(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  Option
+		expect *model.Configuration
+	}{
+		{
+			"advanced-metrics",
+			func() Option {
+				return WithAdvancedParameters([]model.Parameter{
+					{Name: "telemetryPort", Value: 8080},
+					{Name: "telemetryLevel", Value: "detailed"},
+				})
+			}(),
+			&model.Configuration{
+				ResourceMeta: model.ResourceMeta{
+					APIVersion: "bindplane.observiq.com/v2",
+					Kind:       model.KindConfiguration,
+				},
+				Spec: model.ConfigurationSpec{
+					ContentType: "text/yaml",
+					Parameters: []model.Parameter{
+						{Name: "telemetryPort", Value: 8080},
+						{Name: "telemetryLevel", Value: "detailed"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := NewV2(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, output)
+		})
+	}
+}

--- a/provider/resource_configuration_v2.go
+++ b/provider/resource_configuration_v2.go
@@ -450,7 +450,7 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 		configuration.WithAdvancedParameters(advancedParameters),
 	}
 
-	config, err := configuration.NewV2Beta(opts...)
+	config, err := configuration.NewV2(opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create new configuration: %w", err)
 	}


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

Updated the provider to use configuration `v2` instead of `v2beta`.
- New configs will use `v2`
- Existing configs will continue to use `v2beta` until the configuration is updated by Terraform

`v2` and `v2beta` have identical implementations. It is safe to switch between them.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CI passes

I deployed a v2 config using a build from `main` and observed it with the `v2beta` version. I upgraded to this branch and Terraform (correctly) did not prompt me for an apply change. When I updated the config (removed a source) Terraform updated the config correctly. The source was removed and the API version was updated.