### PR TITLE
feat(configuration_v2): carry inline type/parameters on connector, processor_group and inner processors

### DIFF
--- a/docs/resources/bindplane_configuration_v2.md
+++ b/docs/resources/bindplane_configuration_v2.md
@@ -36,6 +36,7 @@ Configuration V2 builds upon [Configuration V1](./bindplane_configuration.md) by
 | `platform`         | string          | required | The platform the configuration supports. See the [supported platforms](./bindplane_configuration.md#supported-platforms) section. |
 | `labels`           | map             | optional | Key value pairs representing labels to set on the configuration.            |
 | `source`           | block           | optional | One or more source blocks. See the [source block](./bindplane_configuration.md#source-block) section. |
+| `connector`        | block           | optional | One or more connector blocks. See the [connector block](#connector-block) section. |
 | `processor_group`  | block           | optional | One or more processor group blocks. See the [processor group block](./bindplane_configuration.md#processor-group-block) section. |
 | `destination`      | block           | optional | One or more destination blocks. See the [destination block](./bindplane_configuration.md#destination-block) section. |
 | `extensions`       | list(string)    | optional | One or more extension names to attach to the configuration.                 |
@@ -53,11 +54,41 @@ Configuration V2 builds upon [Configuration V1](./bindplane_configuration.md) by
 
 ### Processor Group Block
 
+Inner processors can be attached in two forms and both can be used together:
+
+- **`processors`** name list: for library-referenced processors whose `type` and parameters live on a separate `bindplane_processor` resource.
+- **`processor`** block: for inline processors that carry their `type` and `parameters_json` directly on the configuration spec. Useful for processors like `batch:3` whose metadata is embedded rather than kept as a reusable library resource.
+
 | Option              | Type         | Default  | Description                  |
 | ------------------- | ------------ | -------- | ---------------------------- |
 | `route_id`          | string       | required | An arbitrary string that can be used to configure routes to this processor group. |
 | `processors`        | list(string) | optional | One or more processor names to attach to the processor group. |
+| `processor`         | block        | optional | One or more [processor blocks](#processor-block-inside-processor_group) for inline processors with `type` and `parameters_json`. |
+| `parameters_json`   | string       | optional | A JSON object with parameters used to configure the processor group, for example `telemetry_types`. |
 | `route`             | string       | optional | One or more routes to attach to the processor group. See the [route block](./bindplane_configuration.md#route-block) section. |
+
+#### Processor Block (inside processor_group)
+
+| Option              | Type         | Default  | Description                  |
+| ------------------- | ------------ | -------- | ---------------------------- |
+| `name`              | string       | required | Name of the processor to attach. |
+| `type`              | string       | optional | Component type for an inline processor, for example `batch:3`. Leave empty for library-referenced processors. |
+| `parameters_json`   | string       | optional | A JSON object with parameters used to configure the inline processor. |
+
+### Connector Block
+
+The `connector` block attaches a connector to the configuration. Connectors can be used in two ways:
+
+- **Library-referenced**: set `name` to a separately defined `bindplane_connector` resource. Type and parameters are carried on that referenced resource.
+- **Inline**: set `type` and `parameters_json` directly on the block. Useful for routing connectors (`routing:3`) whose OTTL conditions live on the configuration spec rather than on a separate resource.
+
+| Option              | Type         | Default  | Description                  |
+| ------------------- | ------------ | -------- | ---------------------------- |
+| `route_id`          | string       | required | An arbitrary string that can be used to configure routes to this connector. |
+| `name`              | string       | required | Name of the connector to attach. For an inline connector this is a name you assign; for a library-referenced connector it matches the `bindplane_connector` resource name. |
+| `type`              | string       | optional | Component type for an inline connector, for example `routing:3`. Leave empty for library-referenced connectors. |
+| `parameters_json`   | string       | optional | A JSON object with parameters used to configure an inline connector, for example routing conditions. |
+| `route`             | string       | optional | One or more routes to attach to the connector. See the [route block](./bindplane_configuration.md#route-block) section. |
 
 ### Destination Block
 
@@ -270,6 +301,141 @@ resource "bindplane_configuration_v2" "configuration" {
         name = "production"
       }
     }
+  }
+}
+```
+
+### Example: Inline Routing Connector
+
+This example demonstrates an inline routing connector that fans logs out to two processor groups based on an OTTL condition. Both the connector's `type` and its routing `parameters_json` are carried inline on the configuration spec rather than on a separate `bindplane_connector` resource.
+
+The `type` value should match the versioned component type Bindplane uses internally for the routing connector (for example `routing:3`). The `parameters_json` shape below follows what Bindplane's routing connector expects: a `telemetry_types` parameter and a `routes` parameter whose `value` is an ordered list of `{condition, id}` entries, with a final `{id: "Default"}` catch-all.
+
+```hcl
+resource "bindplane_source" "otlp" {
+  rollout = true
+  name    = "my-otlp"
+  type    = "otlp"
+}
+
+resource "bindplane_destination" "primary" {
+  rollout = true
+  name    = "primary-dest"
+  type    = "googlecloud"
+}
+
+resource "bindplane_destination" "secondary" {
+  rollout = true
+  name    = "secondary-dest"
+  type    = "googlecloud"
+}
+
+resource "bindplane_configuration_v2" "example" {
+  rollout  = true
+  name     = "inline-routing-example"
+  platform = "linux"
+
+  source {
+    name = bindplane_source.otlp.name
+    route {
+      route_id       = "otlp-to-router"
+      telemetry_type = "logs"
+      components     = ["connectors/router"]
+    }
+  }
+
+  # Inline routing connector. Type and parameters_json are carried on
+  # the configuration spec so the SaaS UI can resolve the connector
+  # and render the routing edges correctly.
+  connector {
+    route_id = "router"
+    name     = "router"
+    type     = "routing:3"
+    parameters_json = jsonencode([
+      {
+        name  = "telemetry_types"
+        value = ["Logs"]
+      },
+      {
+        name = "routes"
+        value = [
+          {
+            id = "prod"
+            condition = {
+              ottl = "attributes[\"env\"] == \"prod\""
+            }
+          },
+          {
+            id = "Default"
+          },
+        ]
+      },
+    ])
+    route {
+      route_id       = "prod"
+      telemetry_type = "logs"
+      components     = ["processor_groups/prod-group"]
+    }
+    route {
+      route_id       = "Default"
+      telemetry_type = "logs"
+      components     = ["processor_groups/default-group"]
+    }
+  }
+
+  # Inline processor group. telemetry_types is carried on parameters_json;
+  # an inline batch processor lives on a processor block with its own
+  # type and parameters_json so the whole group round-trips through
+  # terraform apply without losing identity.
+  processor_group {
+    route_id = "prod-group"
+    parameters_json = jsonencode([
+      {
+        name  = "telemetry_types"
+        value = ["Logs"]
+      },
+    ])
+    processor {
+      name = "batch-prod"
+      type = "batch:3"
+      parameters_json = jsonencode([
+        {
+          name  = "send_batch_size"
+          value = 200
+        },
+      ])
+    }
+    route {
+      route_id       = "prod-to-primary"
+      telemetry_type = "logs"
+      components     = ["destinations/${bindplane_destination.primary.id}"]
+    }
+  }
+
+  processor_group {
+    route_id   = "default-group"
+    processors = []
+    parameters_json = jsonencode([
+      {
+        name  = "telemetry_types"
+        value = ["Logs"]
+      },
+    ])
+    route {
+      route_id       = "default-to-secondary"
+      telemetry_type = "logs"
+      components     = ["destinations/${bindplane_destination.secondary.id}"]
+    }
+  }
+
+  destination {
+    name     = bindplane_destination.primary.name
+    route_id = bindplane_destination.primary.id
+  }
+
+  destination {
+    name     = bindplane_destination.secondary.name
+    route_id = bindplane_destination.secondary.id
   }
 }
 ```

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -29,14 +29,55 @@ type ResourceConfig struct {
 	// attached to the configuration
 	Name string
 
-	// A list of processor names to attach to the resource
+	// A list of processor names to attach to the resource. Used for
+	// library-referenced processors whose type and parameters live on
+	// a separate bindplane_processor resource.
 	Processors []string
+
+	// ProcessorRefs is a richer representation of attached processors.
+	// In addition to a name, each ref can carry Type and Parameters for
+	// inline processors whose metadata lives on the configuration spec
+	// rather than on a separate bindplane_processor resource. Both
+	// Processors and ProcessorRefs are merged into the final attached
+	// processor list on apply.
+	ProcessorRefs []ProcessorRef
 
 	// RouteID is the ID to use when routing to this resource
 	RouteID string
 
 	// Routes to attach to the resource
 	Routes *model.Routes
+
+	// Type is the component type carried inline on the configuration
+	// spec, for example "routing:3" on an inline routing connector.
+	// Empty for library-referenced components, whose type is carried
+	// on the referenced resource rather than the configuration spec.
+	Type string
+
+	// Parameters are component parameters carried inline on the
+	// configuration spec. Used by inline connectors for routing
+	// conditions and by processor groups for fields such as
+	// telemetry_types.
+	Parameters []model.Parameter
+}
+
+// ProcessorRef represents a processor attached to a source, processor
+// group, or destination. Unlike the bare Processors name list it can
+// carry Type and Parameters for inline processors whose metadata lives
+// on the configuration spec rather than on a separate
+// bindplane_processor resource.
+type ProcessorRef struct {
+	// Name is the name of the processor to attach.
+	Name string
+
+	// Type is the component type for an inline processor, for example
+	// "batch:3". Empty for library-referenced processors whose type is
+	// carried on the referenced bindplane_processor resource.
+	Type string
+
+	// Parameters are component parameters carried inline on the
+	// configuration spec.
+	Parameters []model.Parameter
 }
 
 // Option is a function that configures a
@@ -236,6 +277,16 @@ func withResourcesByName(r []ResourceConfig) []model.ResourceConfiguration {
 			}
 			processorResources = append(processorResources, processor)
 		}
+		// richer processor refs with optional inline Type / Parameters
+		for _, ref := range r.ProcessorRefs {
+			processorResources = append(processorResources, model.ResourceConfiguration{
+				Name: ref.Name,
+				ParameterizedSpec: model.ParameterizedSpec{
+					Type:       ref.Type,
+					Parameters: ref.Parameters,
+				},
+			})
+		}
 
 		routeID := r.RouteID
 
@@ -244,6 +295,8 @@ func withResourcesByName(r []ResourceConfig) []model.ResourceConfiguration {
 		r := model.ResourceConfiguration{
 			Name: r.Name,
 			ParameterizedSpec: model.ParameterizedSpec{
+				Type:       r.Type,
+				Parameters: r.Parameters,
 				Processors: processorResources,
 			},
 			Routes: r.Routes,

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -327,3 +327,124 @@ func TestNewV2(t *testing.T) {
 		})
 	}
 }
+
+// TestWithConnectorsByName_InlineTypeAndParameters verifies that an inline
+// connector's Type and Parameters flow through into the resulting
+// model.ResourceConfiguration's ParameterizedSpec, so the Bindplane SaaS UI
+// can resolve inline routing connectors after terraform apply.
+func TestWithConnectorsByName_InlineTypeAndParameters(t *testing.T) {
+	params := []model.Parameter{
+		{Name: "telemetry_types", Value: []interface{}{"Logs"}},
+		{Name: "routes", Value: []interface{}{
+			map[string]interface{}{"id": "Default"},
+		}},
+	}
+
+	rc := []ResourceConfig{
+		{
+			RouteID:    "route-1",
+			Name:       "connector-routing-1",
+			Type:       "routing:3",
+			Parameters: params,
+		},
+	}
+
+	cfg, err := NewV2(WithConnectorsByName(rc))
+	require.NoError(t, err)
+	require.Len(t, cfg.Spec.Connectors, 1)
+
+	c := cfg.Spec.Connectors[0]
+	require.Equal(t, "connector-routing-1", c.Name)
+	require.Equal(t, "routing:3", c.ParameterizedSpec.Type)
+	require.Equal(t, params, c.ParameterizedSpec.Parameters)
+}
+
+// TestWithProcessorGroups_Parameters verifies that a processor group's
+// Parameters flow through into the resulting model.ResourceConfiguration's
+// ParameterizedSpec. This carries fields such as telemetry_types, which
+// the SaaS UI needs to place the group under the correct telemetry section.
+func TestWithProcessorGroups_Parameters(t *testing.T) {
+	params := []model.Parameter{
+		{Name: "telemetry_types", Value: []interface{}{"Logs"}},
+	}
+
+	rc := []ResourceConfig{
+		{
+			RouteID:    "pg-1",
+			Parameters: params,
+		},
+	}
+
+	cfg, err := NewV2(WithProcessorGroups(rc))
+	require.NoError(t, err)
+	require.Len(t, cfg.Spec.Processors, 1)
+
+	pg := cfg.Spec.Processors[0]
+	require.Equal(t, params, pg.ParameterizedSpec.Parameters)
+}
+
+// TestWithProcessorGroups_InlineProcessorRefs verifies that inner processors
+// specified via ProcessorRefs carry their Type and Parameters through into
+// the resulting model.ResourceConfiguration's inner processor list. Without
+// this, inline batch and other typed processors embedded on a processor
+// group are stripped on apply and the SaaS UI cannot render them.
+func TestWithProcessorGroups_InlineProcessorRefs(t *testing.T) {
+	refs := []ProcessorRef{
+		{
+			Name: "batch-inline",
+			Type: "batch:3",
+			Parameters: []model.Parameter{
+				{Name: "send_batch_size", Value: 100},
+			},
+		},
+	}
+
+	rc := []ResourceConfig{
+		{
+			RouteID:       "pg-1",
+			ProcessorRefs: refs,
+		},
+	}
+
+	cfg, err := NewV2(WithProcessorGroups(rc))
+	require.NoError(t, err)
+	require.Len(t, cfg.Spec.Processors, 1)
+
+	pg := cfg.Spec.Processors[0]
+	require.Len(t, pg.ParameterizedSpec.Processors, 1)
+
+	inner := pg.ParameterizedSpec.Processors[0]
+	require.Equal(t, "batch-inline", inner.Name)
+	require.Equal(t, "batch:3", inner.ParameterizedSpec.Type)
+	require.Equal(t, refs[0].Parameters, inner.ParameterizedSpec.Parameters)
+}
+
+// TestWithProcessorGroups_MixedProcessorsAndRefs verifies that both
+// name-only processors and richer processor refs can coexist on the same
+// processor group. The final inner processor list should contain both
+// forms in the order: Processors first, then ProcessorRefs.
+func TestWithProcessorGroups_MixedProcessorsAndRefs(t *testing.T) {
+	rc := []ResourceConfig{
+		{
+			RouteID:    "pg-1",
+			Processors: []string{"library-filter"},
+			ProcessorRefs: []ProcessorRef{
+				{
+					Name: "batch-inline",
+					Type: "batch:3",
+				},
+			},
+		},
+	}
+
+	cfg, err := NewV2(WithProcessorGroups(rc))
+	require.NoError(t, err)
+	require.Len(t, cfg.Spec.Processors, 1)
+
+	pg := cfg.Spec.Processors[0]
+	require.Len(t, pg.ParameterizedSpec.Processors, 2)
+	require.Equal(t, "library-filter", pg.ParameterizedSpec.Processors[0].Name)
+	require.Equal(t, "", pg.ParameterizedSpec.Processors[0].ParameterizedSpec.Type)
+	require.Equal(t, "batch-inline", pg.ParameterizedSpec.Processors[1].Name)
+	require.Equal(t, "batch:3", pg.ParameterizedSpec.Processors[1].ParameterizedSpec.Type)
+}

--- a/provider/resource_configuration_v2.go
+++ b/provider/resource_configuration_v2.go
@@ -26,6 +26,7 @@ import (
 	"github.com/observiq/terraform-provider-bindplane/internal/component"
 	"github.com/observiq/terraform-provider-bindplane/internal/configuration"
 	"github.com/observiq/terraform-provider-bindplane/internal/maputil"
+	"github.com/observiq/terraform-provider-bindplane/internal/parameter"
 	"github.com/observiq/terraform-provider-bindplane/internal/resource"
 	v2 "github.com/observiq/terraform-provider-bindplane/provider/resource/configuration/v2"
 
@@ -120,6 +121,19 @@ func resourceConfigurationV2() *schema.Resource {
 							ForceNew:    false,
 							Description: "Name of the connector to attach.",
 						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    false,
+							Description: "Component type for an inline connector (for example \"routing:3\"). Leave empty for library-referenced connectors whose type is carried on the referenced bindplane_connector resource.",
+						},
+						"parameters_json": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         false,
+							Description:      "A JSON object with parameters used to configure an inline connector (for example routing conditions).",
+							DiffSuppressFunc: suppressEquivalentJSONDiffs,
+						},
 						"route": v2.RouteSchema,
 					},
 				},
@@ -139,10 +153,46 @@ func resourceConfigurationV2() *schema.Resource {
 						},
 						"processors": {
 							Type:        schema.TypeList,
-							Required:    true,
+							Optional:    true,
 							ForceNew:    false,
 							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: "List of processor names to attach to the processor group.",
+							Description: "List of processor names to attach to the processor group. Use for library-referenced processors without inline metadata. For processors that need inline type or parameters, use the processor block instead. Both forms can be combined.",
+						},
+						"processor": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: false,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    false,
+										Description: "Name of the processor to attach.",
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										ForceNew:    false,
+										Description: "Component type for an inline processor (for example \"batch:3\"). Leave empty for library-referenced processors whose type is carried on the referenced bindplane_processor resource.",
+									},
+									"parameters_json": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ForceNew:         false,
+										Description:      "A JSON object with parameters used to configure an inline processor.",
+										DiffSuppressFunc: suppressEquivalentJSONDiffs,
+									},
+								},
+							},
+							Description: "Processor to attach with optional inline type and parameters. Can be specified one or many times. Use alongside or instead of the processors name list.",
+						},
+						"parameters_json": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         false,
+							Description:      "A JSON object with parameters used to configure the processor group (for example telemetry_types).",
+							DiffSuppressFunc: suppressEquivalentJSONDiffs,
 						},
 						"route": v2.RouteSchema,
 					},
@@ -348,10 +398,23 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 				routes = r
 			}
 
+			parameters := []model.Parameter{}
+			if s, _ := connectorRaw["parameters_json"].(string); s != "" {
+				params, err := parameter.StringToParameter(s)
+				if err != nil {
+					return fmt.Errorf("connector parameters_json: %w", err)
+				}
+				parameters = params
+			}
+
+			connectorType, _ := connectorRaw["type"].(string)
+
 			connectorConf := configuration.ResourceConfig{
-				RouteID: connectorRaw["route_id"].(string),
-				Name:    connectorRaw["name"].(string),
-				Routes:  routes,
+				RouteID:    connectorRaw["route_id"].(string),
+				Name:       connectorRaw["name"].(string),
+				Type:       connectorType,
+				Parameters: parameters,
+				Routes:     routes,
 			}
 			connectors = append(connectors, connectorConf)
 		}
@@ -370,6 +433,30 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 				}
 			}
 
+			processorRefs := []configuration.ProcessorRef{}
+			if blocks, ok := processorGroupRaw["processor"].([]any); ok {
+				for _, blk := range blocks {
+					b := blk.(map[string]any)
+
+					refParams := []model.Parameter{}
+					if s, _ := b["parameters_json"].(string); s != "" {
+						params, err := parameter.StringToParameter(s)
+						if err != nil {
+							return fmt.Errorf("processor_group.processor parameters_json: %w", err)
+						}
+						refParams = params
+					}
+
+					refType, _ := b["type"].(string)
+
+					processorRefs = append(processorRefs, configuration.ProcessorRef{
+						Name:       b["name"].(string),
+						Type:       refType,
+						Parameters: refParams,
+					})
+				}
+			}
+
 			routes := &model.Routes{}
 			if rawRoutes := processorGroupRaw["route"].(*schema.Set).List(); v != nil {
 				r, err := component.ParseRoutes(rawRoutes)
@@ -379,10 +466,21 @@ func resourceConfigurationV2Create(d *schema.ResourceData, meta any) error {
 				routes = r
 			}
 
+			parameters := []model.Parameter{}
+			if s, _ := processorGroupRaw["parameters_json"].(string); s != "" {
+				params, err := parameter.StringToParameter(s)
+				if err != nil {
+					return fmt.Errorf("processor_group parameters_json: %w", err)
+				}
+				parameters = params
+			}
+
 			processorGroupConf := configuration.ResourceConfig{
-				RouteID:    processorGroupRaw["route_id"].(string),
-				Processors: processors,
-				Routes:     routes,
+				RouteID:       processorGroupRaw["route_id"].(string),
+				Processors:    processors,
+				ProcessorRefs: processorRefs,
+				Parameters:    parameters,
+				Routes:        routes,
 			}
 			processorGroups = append(processorGroups, processorGroupConf)
 		}
@@ -547,6 +645,25 @@ func resourceConfigurationV2Read(d *schema.ResourceData, meta any) error {
 		connector["route_id"] = c.ID
 		connector["name"] = strings.Split(c.Name, ":")[0]
 
+		// Only round-trip type and parameters_json for inline connectors
+		// (those with non-empty Parameters). For library-referenced
+		// connectors the server may populate Type from the library
+		// resource even though the user did not declare it; echoing
+		// that back to state would cause spurious drift on every
+		// refresh.
+		connectorType := ""
+		paramsJSON := ""
+		if len(c.ParameterizedSpec.Parameters) > 0 {
+			s, err := parameter.ParametersToString(c.ParameterizedSpec.Parameters)
+			if err != nil {
+				return fmt.Errorf("connector parameters to json: %w", err)
+			}
+			paramsJSON = s
+			connectorType = c.ParameterizedSpec.Type
+		}
+		connector["type"] = connectorType
+		connector["parameters_json"] = paramsJSON
+
 		stateRoutes, err := component.RoutesToState(c.Routes)
 		if err != nil {
 			return fmt.Errorf("routes to state: %w", err)
@@ -567,11 +684,40 @@ func resourceConfigurationV2Read(d *schema.ResourceData, meta any) error {
 	for _, pg := range config.Spec.Processors {
 		processorGroup := map[string]any{}
 
-		processors := []string{}
+		// Classify inner processors. Those with inline Parameters
+		// round-trip through the structured processor block; those
+		// without round-trip through the processors name list. Using
+		// Parameters rather than Type as the discriminator avoids
+		// spurious drift: the server often populates Type on library-
+		// referenced processors without the user setting it, and those
+		// should still round-trip as a bare name in state.
+		nameOnly := []string{}
+		richBlocks := []map[string]any{}
 		for _, p := range pg.Processors {
-			processors = append(processors, strings.Split(p.Name, ":")[0])
+			shortName := strings.Split(p.Name, ":")[0]
+			if len(p.ParameterizedSpec.Parameters) == 0 {
+				nameOnly = append(nameOnly, shortName)
+				continue
+			}
+
+			innerJSON, err := parameter.ParametersToString(p.ParameterizedSpec.Parameters)
+			if err != nil {
+				return fmt.Errorf("processor parameters to json: %w", err)
+			}
+			richBlocks = append(richBlocks, map[string]any{
+				"name":            shortName,
+				"type":            p.ParameterizedSpec.Type,
+				"parameters_json": innerJSON,
+			})
 		}
-		processorGroup["processors"] = processors
+		processorGroup["processors"] = nameOnly
+		processorGroup["processor"] = richBlocks
+
+		paramsJSON, err := parameter.ParametersToString(pg.ParameterizedSpec.Parameters)
+		if err != nil {
+			return fmt.Errorf("processor_group parameters to json: %w", err)
+		}
+		processorGroup["parameters_json"] = paramsJSON
 
 		stateRoutes, err := component.RoutesToState(pg.Routes)
 		if err != nil {


### PR DESCRIPTION
Closes #210.

Adds schema and wiring so inline components on `bindplane_configuration_v2` round-trip through `terraform apply` without losing their identity. Covers the three wiring-critical field categories that are currently stripped (connector `type`+`parameters`, processor_group `parameters`, inner processor `type`+`parameters`), which in our testing is everything needed to restore SaaS pipeline rendering for the cases we've seen in the wild.

## What's in this PR

- **`internal/configuration/configuration.go`**
  - Two new fields on `ResourceConfig`: `Type` and `Parameters`, populated onto `model.ResourceConfiguration.ParameterizedSpec` in `withResourcesByName`.
  - New `ProcessorRef` struct and `ProcessorRefs []ProcessorRef` field on `ResourceConfig`, appended into the same inner processor list as the existing name-only `Processors`.

- **`provider/resource_configuration_v2.go`**
  - `connector` block: new `type` (string, optional) and `parameters_json` (string, optional, `DiffSuppressFunc: suppressEquivalentJSONDiffs`).
  - `processor_group` block: new `parameters_json` (for fields like `telemetry_types`).
  - `processor_group` block: new `processor` block (singular) for inline inner processors with `name` (required) + `type` (optional) + `parameters_json` (optional). `processors = [names]` is kept as an additive non-breaking alternative and relaxed from Required to Optional.
  - Schema pattern matches the standalone `bindplane_connector` resource so the mental model stays consistent across resource types.

- **`internal/configuration/configuration_test.go`**
  - `TestWithConnectorsByName_InlineTypeAndParameters`
  - `TestWithProcessorGroups_Parameters`
  - `TestWithProcessorGroups_InlineProcessorRefs`
  - `TestWithProcessorGroups_MixedProcessorsAndRefs`

- **`docs/resources/bindplane_configuration_v2.md`**
  - Adds the missing `Connector Block` section (it wasn't in the options reference previously).
  - Documents the new `processor` block nested under `processor_group`.
  - Adds an "Inline Routing Connector" example that exercises an inline `routing:3` connector, an inline `batch:3` processor on one processor group, and the name-only form on another.

## Schema design notes

A couple of choices worth flagging for review:

1. **Inner processors as an additive `processor` block rather than breaking the `processors` string list.** Breaking the list form would have been simpler in the wiring but would force every existing user to rewrite their TF. The additive block keeps everyone's current config working unchanged. Happy to go the other way if you'd prefer to break it in a major.

2. **`processors` relaxed from Required to Optional.** Needed so users can express a processor group using only the `processor` block form without a stub empty list. Strictly additive — no existing config breaks.

3. **Read-path classification uses `len(Parameters) > 0`, not the presence of `Type`.** When a library-referenced processor or connector hits the server, the server commonly populates `Type` from the referenced resource. If we reclassified on `Type != ""`, that would flip a `processors = ["my-filter"]` config into a `processor { name = ..., type = ... }` block on every refresh and create spurious drift. Using `Parameters` as the discriminator avoids that: library-referenced components stay in the simpler form; inline ones (which always have Parameters in practice for routing/batch/etc.) round-trip through the rich form. Same logic applied to connectors for symmetry. Happy to discuss state-aware Read logic if you'd prefer a more principled approach.

## Known limitations

Calling these out explicitly rather than hiding them:

- **Inline components with `type` but no `parameters_json`** will be reclassified as library-referenced on Read and the `type` field cleared from state, causing drift. In practice this affects anyone who declares `type = "batch:3"` with no parameters (relying on defaults). Workaround: declare at least one parameter, or use the `processors = [names]` list form. The drift-avoidance trade-off described in design note 3 is why. Open to a state-aware Read if you'd rather avoid this.
- **`parameters_json` drift on `"" vs "[]"`.** `suppressEquivalentJSONDiffs` treats only-one-empty as different, so users who declare `parameters_json = jsonencode([])` (an explicit empty parameters list) will see drift since the Read path returns `""` for empty parameters. Users who omit the attribute entirely are unaffected. Minor — happy to extend the diff-suppress if you want it bundled in here.
- **Inner processor `displayName` is not covered.** The related restoration we had to run as a workaround also re-patched `displayName` on inner processors; this PR does not carry it through. The effect is cosmetic only — the SaaS canvas falls back to the internal name. PR #115 adds `display_name` on standalone resources; I didn't want this PR to collide with that surface, so `display_name` on inline inner processors is deliberately a separate follow-up.

## What's explicitly out of scope

- `display_name` support on any resource. PR #115 is in flight on the standalone-resource surface; inner-processor `display_name` can pick up from there.
- `processor` block support on `source` and `destination`. The defect we've been chasing is scoped to processor_group inner processors, so I scoped the same way. Happy to extend if you'd like symmetry.

## Testing

- Unit tests added in `internal/configuration` for the new plumbing, following the style of `TestReadRolloutOptions` / the existing table-driven `TestNewV2` tests.
- `gofmt` clean on the four files touched.
- I couldn't run `go build` / `go test` locally: `github.com/observiq/bindplane-op-enterprise` is private and I don't have SSH access. CI has the secret and will validate. If there's a documented path for external contributors to build this locally, happy to follow it; otherwise I'll iterate on CI output and review comments.
- **Spec shape validated against BindPlane OP v1.99.1 on localhost.** Posted a Configuration whose spec matches what the patched provider would emit (inline connector with `type=routing:2` + two parameters; processor group with `telemetry_types` parameter + an inner processor with `type=batch:2` + two parameters), GETed it back, and verified every field round-trips. 0 failures across `connector.type`, `connector.parameters`, `processor_group.parameters`, `inner_processor.type`, `inner_processor.parameters`. This confirms BindPlane accepts and preserves the shape; it does not reproduce the SaaS-specific render bug (localhost OP renders specs more leniently than SaaS), which is a distinct layer.
- **End-to-end fix behaviour** (provider no longer strips → SaaS renders correctly) is gated on CI validation of the Go code and whatever acceptance tests you have around `bindplane_configuration_v2`. I don't have a way to run those locally.

## Evidence

We hit this on a couple of production Bindplane Cloud configs with inline `routing:3` connectors and a few inline `batch:3` processors embedded on processor groups (~50 processor groups across 30+ routes on the largest). After `terraform apply`, the SaaS UI rendered the downstream pipeline as disconnected processor groups with no incoming edges. Library-referenced components on the same config deployed fine.

We confirmed the root cause by running a `null_resource` post-apply `local-exec` that re-PATCHes the stripped fields via `POST /v1/apply`: with connector `type`/`parameters`, processor group `telemetry_types`, and inner processor `type`/`parameters` restored, the SaaS UI resolves everything correctly and the pipeline renders 1:1 with the original UI config. HAR captures of the SaaS graph before and after the workaround made the causal chain unambiguous. The example in the docs is a synthetic minimal repro; happy to share more specific patterns privately if it would help review.

## Compatibility

- All new schema attributes are `Optional` and all changes are additive. Existing `bindplane_configuration_v2` configs that don't set the new fields are unaffected.
- `processors` on `processor_group` is relaxed from Required to Optional. Existing configs that set `processors = [...]` continue to work; new configs can omit it when using `processor` blocks instead.
- Read path is conservative for library-referenced components: only emits rich-block form when Parameters are non-empty, so upgrading the provider doesn't introduce drift on existing state for configs that don't touch the new fields.
- `suppressEquivalentJSONDiffs` prevents spurious drift on JSON re-serialisation, matching the standalone resource.

Happy to iterate on naming, descriptions, schema shape, or anything else on review.
