### PR TITLE
fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '.github/CODEOWNERS'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/observIQ/terraform-provider-bindplane/security/code-scanning/17](https://github.com/observIQ/terraform-provider-bindplane/security/code-scanning/17)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained.  
Best fix with no functional change: set workflow-level permissions to minimal read access (`contents: read`), since the workflow only needs to read repository contents for checkout/validation and does not perform writes.

Edit **`.github/workflows/codeowners-validator.yml`** near the top-level keys, adding:

- `permissions:`
- `contents: read`

Place it after the `on:` block (or before `jobs:`) at root indentation level.

No imports, methods, or extra dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
